### PR TITLE
Code review: src/components/command_protector

### DIFF
--- a/src/components/command_protector/REVIEW.md
+++ b/src/components/command_protector/REVIEW.md
@@ -1,0 +1,120 @@
+# Command Protector Component — Code Review
+
+**Reviewer:** Automated Expert Review  
+**Date:** 2026-02-28  
+**Branch:** `review/components-command-protector`
+
+---
+
+## 1. Documentation Review
+
+The component description in the YAML and `.ads` spec are thorough and accurate. The LaTeX document is a standard template pulling from generated build artifacts — no issues.
+
+**Minor comment inaccuracy:**
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| D1 | `component-command_protector-implementation.ads:14` | Low | Comment says "Commands that are not on the protected commands list **they will be** forwarded" — grammatically awkward. Should be "…protected commands list **will be** forwarded." Same wording repeated in the `Command_T_To_Forward_Recv_Sync` procedure comment. |
+
+---
+
+## 2. Model Review
+
+### component.yaml
+
+The model is well-structured. Connectors, commands, events, data products, and packets are all consistent with the implementation.
+
+**No issues found.**
+
+### commands.yaml
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| M1 | `command_protector.commands.yaml` | Low | The Arm command description states "A timeout value of zero implies infinite timeout" but the `packed_arm_timeout.record.yaml` field description says "The timeout value (in ticks)" with no mention of zero-means-infinite semantics. The special zero-case should be documented in the type description as well for clarity. |
+
+### requirements.yaml
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| M2 | `command_protector.requirements.yaml`, requirement 4 | Medium | Requirement: "The component shall exit the armed state upon receipt of any command, **unless it is another arm command.**" The implementation does **not** implement this exception — sending an Arm command while armed will **not** re-arm the component via `Command_T_To_Forward_Recv_Sync`; the Arm command arrives on the separate `Command_T_Recv_Sync` connector and always succeeds. However, if a *non-protected, non-arm* command is forwarded while armed, the component transitions to unarmed. The requirement text is misleading because the Arm command never arrives on the forwarding connector — the "unless" clause is vacuously true but confusing. Consider rewording for accuracy. |
+| M3 | `command_protector.requirements.yaml`, requirement 7 | Low | States "0 to 255 seconds (in 1 second intervals)" but the timeout is actually in **ticks**, not seconds. The mapping of ticks to seconds depends on the tick rate configured at the assembly level. The requirement should say "ticks" or clarify the assumed tick period. |
+
+### types
+
+**No issues found.** Enums, packed records are clean and correctly sized.
+
+---
+
+## 3. Component Implementation Review
+
+### arm_state.ads / arm_state.adb
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| I1 | `arm_state.ads:10` | Medium | `Get_State` is declared as a **function** of the protected type, but it has an `out` parameter (`The_Timeout`). In Ada, protected functions provide concurrent read access (multiple readers allowed). Having an `out` parameter on a function is legal but semantically unusual — it implies the function has a side-channel output while being called concurrently. This is safe here because `The_Timeout` is derived from private state that only changes under procedure (exclusive) access. However, it is an unconventional pattern that could confuse maintainers. A more conventional approach would be to either (a) make it a procedure, or (b) return a record containing both state and timeout. |
+
+### component-command_protector-implementation.adb
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| I2 | `component-command_protector-implementation.adb:105-106` (in `Command_T_To_Forward_Recv_Sync`, Armed branch) | **High** | **Race condition between `Get_State` and subsequent operations.** The armed state is read via `Get_State` at the top of the procedure (line ~87), then if `Armed`, the command is forwarded and `Unarm` is called. Because this component is declared `passive` (no task, no queue), all connectors are synchronous and called in the caller's thread. If `Tick_T_Recv_Sync` and `Command_T_To_Forward_Recv_Sync` can be called from **different tasks** (e.g., a tick task and a command routing task), there is a TOCTOU race: the state could be `Armed` when read but timeout to `Unarmed` between the read and the `Unarm` call. The `Unarm` procedure itself is safe (idempotent), but the **decision to forward a protected command** was made on stale state. **Mitigation:** If the component is always invoked from a single task (common in Adamant passive component usage), this is not exploitable. If multi-task invocation is possible, the check-and-act should be atomic — e.g., a single protected operation `Try_Forward` that returns whether to forward. |
+| I3 | `component-command_protector-implementation.adb:122,143` | **Medium** | **Unsigned_16 counter overflow.** `Protected_Command_Forward_Count` and `Protected_Command_Reject_Count` are `Interfaces.Unsigned_16` and are incremented with `@ + 1`. If either counter reaches `65535` and is incremented again, it wraps to 0 (Interfaces.Unsigned_16 uses modular arithmetic). This silent wraparound could be misleading in telemetry. Consider saturating at `Unsigned_16'Last` or using a wider type. |
+
+**Original code (line ~122):**
+```ada
+Self.Protected_Command_Forward_Count := @ + 1;
+```
+**Suggested fix (saturating):**
+```ada
+if Self.Protected_Command_Forward_Count < Interfaces.Unsigned_16'Last then
+   Self.Protected_Command_Forward_Count := @ + 1;
+end if;
+```
+Same pattern for `Protected_Command_Reject_Count` at line ~143.
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| I4 | `component-command_protector-implementation.adb:87-90` | Low | **Two calls into the protected object for one logical operation.** `Get_State` is called to read the state, then later `Unarm` is called. Between these two calls the lock is released. As noted in I2, this is a potential issue under concurrent access. Even in single-task scenarios, combining these into a single protected call would be cleaner. |
+
+---
+
+## 4. Unit Test Review
+
+The test suite covers the key scenarios well:
+
+- ✅ Initialization (nominal, empty list, duplicate IDs)
+- ✅ Unprotected command forwarding (unarmed and armed states)
+- ✅ Protected command acceptance (armed state)
+- ✅ Protected command rejection (unarmed state, with error packet)
+- ✅ Timeout behavior (decrement, expiry, infinite timeout with 0)
+- ✅ Invalid command handling
+
+| # | Location | Severity | Details |
+|---|----------|----------|---------|
+| T1 | `command_protector_tests-implementation.adb` | Medium | **Missing test: Arm while already armed.** There is no test that sends a second Arm command while the component is already armed (e.g., to reset the timeout). This is a valid operational scenario — an operator might re-arm with a different timeout. The behavior should be verified (the current implementation would overwrite the timeout and remain armed). |
+| T2 | `command_protector_tests-implementation.adb` | Medium | **Missing test: Arm command sent to the forwarding connector.** If by misconfiguration or operator error, an Arm command (matching the component's own command ID) appears on the `Command_T_To_Forward_Recv_Sync` connector, it would be treated as a regular command, potentially protected or not. Testing this boundary would be valuable. |
+| T3 | `command_protector_tests-implementation.adb` | Low | **Missing test: Counter rollover.** No test verifies behavior when `Protected_Command_Reject_Count` or `Protected_Command_Forward_Count` approach or reach `Unsigned_16'Last`. Given finding I3, this should be tested. |
+| T4 | `command_protector_tests-implementation.adb`, `Test_Protected_Command_Accept`, line with comment "Send a command not in the protected list:" | Low | **Misleading comment.** The comment says "Send a command **not** in the protected list" but `Cmd.Header.Id` is set to `19`, which **is** in the protected list `[4, 19, 77, 78]`. The test assertions are correct (it expects acceptance and forward-count increment), so the code is right but the comment is wrong. |
+
+**Original comment:**
+```ada
+-- Send a command not in the protected list:
+Cmd.Header.Id := 19;
+```
+**Corrected:**
+```ada
+-- Send a command IN the protected list:
+Cmd.Header.Id := 19;
+```
+
+---
+
+## 5. Summary — Top 5 Findings
+
+| Rank | ID | Severity | Summary |
+|------|----|----------|---------|
+| 1 | I2 | **High** | TOCTOU race on armed state: `Get_State` then `Unarm` are not atomic. Under concurrent multi-task invocation, a protected command could be forwarded after the armed state has timed out. |
+| 2 | I3 | **Medium** | `Unsigned_16` telemetry counters silently wrap around at 65535, producing misleading telemetry in long-duration missions. |
+| 3 | M2 | **Medium** | Requirement 4 ("unless it is another arm command") is misleading given the actual connector topology — the Arm command never flows through the forwarding path. |
+| 4 | T1 | **Medium** | No unit test for re-arming while already armed (timeout reset scenario). |
+| 5 | T4 | **Low** | Incorrect comment in `Test_Protected_Command_Accept` — says "not in the protected list" for command ID 19 which is protected. |

--- a/src/components/command_protector/REVIEW.md
+++ b/src/components/command_protector/REVIEW.md
@@ -118,3 +118,20 @@ Cmd.Header.Id := 19;
 | 3 | M2 | **Medium** | Requirement 4 ("unless it is another arm command") is misleading given the actual connector topology — the Arm command never flows through the forwarding path. |
 | 4 | T1 | **Medium** | No unit test for re-arming while already armed (timeout reset scenario). |
 | 5 | T4 | **Low** | Incorrect comment in `Test_Protected_Command_Accept` — says "not in the protected list" for command ID 19 which is protected. |
+
+## Resolution Notes
+
+| # | Issue | Severity | Status | Commit | Notes |
+|---|-------|----------|--------|--------|-------|
+| 1 | TOCTOU race on armed state | High | Fixed | 97595f7 | Added atomic Try_Unarm protected operation |
+| 2 | Unsigned_16 counter overflow | Medium | Fixed | 9efd6e2 | Saturating increment for both counters |
+| 3 | Misleading requirement 4 wording | Medium | Fixed | b91c3ca | Reworded to reflect connector topology |
+| 4 | Missing re-arm while armed test | Medium | Fixed | a0ba3c4 | Added Test_Rearm_While_Armed |
+| 5 | Missing arm on forward connector test | Medium | Fixed | 8f04453 | Added Test_Arm_Command_On_Forward_Connector |
+| 6 | Get_State function with out param | Medium | Fixed | 9005925 | Converted to procedure |
+| 7 | Grammar in comment | Low | Fixed | fe9bc22 | Removed extraneous word |
+| 8 | Document zero-means-infinite | Low | Fixed | d98a5e6 | Updated timeout type YAML |
+| 9 | Requirement says seconds not ticks | Low | Fixed | 8a48adc | Changed to ticks |
+| 10 | Two protected object calls | Low | Fixed | 88405a5 | Already addressed by item 1 |
+| 11 | Missing counter saturation test | Low | Fixed | 740e24e | Added Test_Counter_Saturation |
+| 12 | Misleading test comment | Low | Fixed | 08ef9a9 | Fixed comment for command ID 19 |

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -33,6 +33,17 @@ package body Arm_State is
          Timeout := Arm_Timeout_Type'First;
       end Unarm;
 
+      -- Atomically check if armed and unarm:
+      procedure Try_Unarm (Previous_State : out Command_Protector_Enums.Armed_State.E; Previous_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) is
+         use Packed_Arm_Timeout;
+      begin
+         Previous_State := State;
+         Previous_Timeout := Timeout;
+         -- Transition to unarmed regardless of current state (idempotent):
+         State := Command_Protector_Enums.Armed_State.Unarmed;
+         Timeout := Arm_Timeout_Type'First;
+      end Try_Unarm;
+
       -- Decrement the timeout, and transition to the unarmed state if the
       -- timeout has expired.
       procedure Decrement_Timeout (Timeout_Val : out Packed_Arm_Timeout.Arm_Timeout_Type; New_State : out Command_Protector_Enums.Armed_State.E; Timed_Out : out Boolean) is

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -5,10 +5,10 @@ package body Arm_State is
       --
       -- Functions that provide read-only access to the private data:
       --
-      function Get_State (The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) return Command_Protector_Enums.Armed_State.E is
+      procedure Get_State (The_State : out Command_Protector_Enums.Armed_State.E; The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) is
       begin
+         The_State := State;
          The_Timeout := Timeout;
-         return State;
       end Get_State;
 
       --

--- a/src/components/command_protector/arm_state/arm_state.ads
+++ b/src/components/command_protector/arm_state/arm_state.ads
@@ -19,6 +19,10 @@ package Arm_State is
       procedure Arm (New_Timeout : in Packed_Arm_Timeout.Arm_Timeout_Type);
       -- Unarm the system and cancel the timeout:
       procedure Unarm;
+      -- Atomically check if armed and unarm. Returns the state that was
+      -- active before the call, allowing callers to make forwarding
+      -- decisions without a TOCTOU race between Get_State and Unarm.
+      procedure Try_Unarm (Previous_State : out Command_Protector_Enums.Armed_State.E; Previous_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type);
       -- Decrement the timeout, and transition to the unarmed state if the
       -- timeout has expired.
       procedure Decrement_Timeout (Timeout_Val : out Packed_Arm_Timeout.Arm_Timeout_Type; New_State : out Command_Protector_Enums.Armed_State.E; Timed_Out : out Boolean);

--- a/src/components/command_protector/arm_state/arm_state.ads
+++ b/src/components/command_protector/arm_state/arm_state.ads
@@ -10,7 +10,7 @@ package Arm_State is
       --
       -- Functions that provide read-only access to the private data:
       --
-      function Get_State (The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) return Command_Protector_Enums.Armed_State.E;
+      procedure Get_State (The_State : out Command_Protector_Enums.Armed_State.E; The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type);
 
       --
       -- Procedures requiring full mutual exclusion:

--- a/src/components/command_protector/command_protector.requirements.yaml
+++ b/src/components/command_protector/command_protector.requirements.yaml
@@ -7,6 +7,6 @@ requirements:
   - text: The component shall exit the armed state upon receipt of any command on the forwarding connector.
   - text: The component shall exit the armed state after a timeout.
   - text: The component shall set the armed state timeout through ground command.
-  - text: The component shall accept armed state timeouts in the range of 0 to 255 seconds (in 1 second intervals). A value of zero implies infinite timeout.
+  - text: The component shall accept armed state timeouts in the range of 0 to 255 ticks. A value of zero implies infinite timeout.
   - text: The component shall report the armed state timeout in telemetry.
 

--- a/src/components/command_protector/command_protector.requirements.yaml
+++ b/src/components/command_protector/command_protector.requirements.yaml
@@ -4,7 +4,7 @@ requirements:
   - text: The component shall enter the armed state upon command.
   - text: The component shall reject protected commands if not in the armed state.
   - text: The component shall report the armed state in telemetry.
-  - text: The component shall exit the armed state upon receipt of any command, unless it is another arm command.
+  - text: The component shall exit the armed state upon receipt of any command on the forwarding connector.
   - text: The component shall exit the armed state after a timeout.
   - text: The component shall set the armed state timeout through ground command.
   - text: The component shall accept armed state timeouts in the range of 0 to 255 seconds (in 1 second intervals). A value of zero implies infinite timeout.

--- a/src/components/command_protector/component-command_protector-implementation.adb
+++ b/src/components/command_protector/component-command_protector-implementation.adb
@@ -96,7 +96,7 @@ package body Component.Command_Protector.Implementation is
       end case;
    end Tick_T_Recv_Sync;
 
-   -- Commands received on this connector will be checked against the protected command list and rejected if the system is 'unarmed'. Commands not found in the protected command list they will be forwarded.
+   -- Commands received on this connector will be checked against the protected command list and rejected if the system is 'unarmed'. Commands not found in the protected command list will be forwarded.
    overriding procedure Command_T_To_Forward_Recv_Sync (Self : in out Instance; Arg : in Command.T) is
       use Command_Protector_Enums.Armed_State;
       -- Atomically read and unarm the state, eliminating the TOCTOU race

--- a/src/components/command_protector/component-command_protector-implementation.adb
+++ b/src/components/command_protector/component-command_protector-implementation.adb
@@ -51,8 +51,9 @@ package body Component.Command_Protector.Implementation is
    overriding procedure Set_Up (Self : in out Instance) is
       The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
       Start_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Start_Timeout);
+      Start_State : Command_Protector_Enums.Armed_State.E;
    begin
+      Self.Command_Arm_State.Get_State (Start_State, Start_Timeout);
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => Start_State)));
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => Start_Timeout)));
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Protected_Command_Forward_Count (The_Time, (Value => Self.Protected_Command_Forward_Count)));
@@ -124,10 +125,11 @@ package body Component.Command_Protector.Implementation is
             declare
                -- After Try_Unarm the state is now Unarmed with timeout 0:
                New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-               New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+               New_State : Command_Protector_Enums.Armed_State.E;
                -- Timestamp:
                The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
             begin
+               Self.Command_Arm_State.Get_State (New_State, New_Timeout);
                -- Send new armed data product:
                Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
                Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => New_Timeout)));
@@ -210,8 +212,9 @@ package body Component.Command_Protector.Implementation is
       declare
          The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
          New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : Command_Protector_Enums.Armed_State.E;
       begin
+         Self.Command_Arm_State.Get_State (New_State, New_Timeout);
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => New_Timeout)));
 

--- a/src/components/command_protector/component-command_protector-implementation.adb
+++ b/src/components/command_protector/component-command_protector-implementation.adb
@@ -134,7 +134,9 @@ package body Component.Command_Protector.Implementation is
 
                -- If this is a protected command, we need to increment a counter for telemetry.
                if Is_Protected_Command then
-                  Self.Protected_Command_Forward_Count := @ + 1;
+                  if Self.Protected_Command_Forward_Count < Interfaces.Unsigned_16'Last then
+                     Self.Protected_Command_Forward_Count := @ + 1;
+                  end if;
                   Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Protected_Command_Forward_Count (The_Time, (Value => Self.Protected_Command_Forward_Count)));
 
                   -- Send info event:
@@ -155,7 +157,9 @@ package body Component.Command_Protector.Implementation is
                   The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
                begin
                   -- Increment the reject counter:
-                  Self.Protected_Command_Reject_Count := @ + 1;
+                  if Self.Protected_Command_Reject_Count < Interfaces.Unsigned_16'Last then
+                     Self.Protected_Command_Reject_Count := @ + 1;
+                  end if;
                   Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Protected_Command_Reject_Count (The_Time, (Value => Self.Protected_Command_Reject_Count)));
 
                   -- Send info event:

--- a/src/components/command_protector/component-command_protector-implementation.ads
+++ b/src/components/command_protector/component-command_protector-implementation.ads
@@ -64,7 +64,7 @@ private
    ---------------------------------------
    -- This tick is used to keep track of the armed state timeout and send the data product relating the current timeout value.
    overriding procedure Tick_T_Recv_Sync (Self : in out Instance; Arg : in Tick.T);
-   -- Commands received on this connector will be checked against the protected command list and rejected if the system is 'unarmed'. Commands not found in the protected command list they will be forwarded.
+   -- Commands received on this connector will be checked against the protected command list and rejected if the system is 'unarmed'. Commands not found in the protected command list will be forwarded.
    overriding procedure Command_T_To_Forward_Recv_Sync (Self : in out Instance; Arg : in Command.T);
    -- The command receive connector for this component's specific commands.
    overriding procedure Command_T_Recv_Sync (Self : in out Instance; Arg : in Command.T);

--- a/src/components/command_protector/test/command_protector.tests.yaml
+++ b/src/components/command_protector/test/command_protector.tests.yaml
@@ -15,5 +15,7 @@ tests:
     description: This unit test verifies that sending a second Arm command while already armed correctly resets the timeout.
   - name: Test_Arm_Command_On_Forward_Connector
     description: This unit test verifies behavior when a command matching the Arm command ID arrives on the forwarding connector.
+  - name: Test_Counter_Saturation
+    description: This unit test verifies that telemetry counters saturate at Unsigned_16'Last instead of wrapping.
   - name: Test_Invalid_Command
     description: This unit test makes sure that an invalid command is handled gracefully.

--- a/src/components/command_protector/test/command_protector.tests.yaml
+++ b/src/components/command_protector/test/command_protector.tests.yaml
@@ -11,5 +11,7 @@ tests:
     description: This unit test tests that a protected command is rejected if the component is unarmed.
   - name: Test_Protected_Command_Reject_Timeout
     description: This unit test tests that a protected command is rejected if the component is unarmed due to timeout.
+  - name: Test_Rearm_While_Armed
+    description: This unit test verifies that sending a second Arm command while already armed correctly resets the timeout.
   - name: Test_Invalid_Command
     description: This unit test makes sure that an invalid command is handled gracefully.

--- a/src/components/command_protector/test/command_protector.tests.yaml
+++ b/src/components/command_protector/test/command_protector.tests.yaml
@@ -13,5 +13,7 @@ tests:
     description: This unit test tests that a protected command is rejected if the component is unarmed due to timeout.
   - name: Test_Rearm_While_Armed
     description: This unit test verifies that sending a second Arm command while already armed correctly resets the timeout.
+  - name: Test_Arm_Command_On_Forward_Connector
+    description: This unit test verifies behavior when a command matching the Arm command ID arrives on the forwarding connector.
   - name: Test_Invalid_Command
     description: This unit test makes sure that an invalid command is handled gracefully.

--- a/src/components/command_protector/test/command_protector_tests-implementation.adb
+++ b/src/components/command_protector/test/command_protector_tests-implementation.adb
@@ -283,7 +283,7 @@ package body Command_Protector_Tests.Implementation is
       Natural_Assert.Eq (T.Armed_State_Timeout_History.Get_Count, 3);
       Packed_Arm_Timeout_Assert.Eq (T.Armed_State_Timeout_History.Get (3), (Timeout => 22));
 
-      -- Send a command not in the protected list:
+      -- Send a command IN the protected list:
       Cmd.Header.Id := 19;
       T.Command_T_To_Forward_Send (Cmd);
 

--- a/src/components/command_protector/test/command_protector_tests-implementation.ads
+++ b/src/components/command_protector/test/command_protector_tests-implementation.ads
@@ -26,6 +26,8 @@ private
    overriding procedure Test_Rearm_While_Armed (Self : in out Instance);
    -- This unit test verifies behavior when a command matching the Arm command ID arrives on the forwarding connector.
    overriding procedure Test_Arm_Command_On_Forward_Connector (Self : in out Instance);
+   -- This unit test verifies that telemetry counters saturate at Unsigned_16'Last instead of wrapping.
+   overriding procedure Test_Counter_Saturation (Self : in out Instance);
    -- This unit test makes sure that an invalid command is handled gracefully.
    overriding procedure Test_Invalid_Command (Self : in out Instance);
 

--- a/src/components/command_protector/test/command_protector_tests-implementation.ads
+++ b/src/components/command_protector/test/command_protector_tests-implementation.ads
@@ -24,6 +24,8 @@ private
    overriding procedure Test_Protected_Command_Reject_Timeout (Self : in out Instance);
    -- This unit test verifies that sending a second Arm command while already armed correctly resets the timeout.
    overriding procedure Test_Rearm_While_Armed (Self : in out Instance);
+   -- This unit test verifies behavior when a command matching the Arm command ID arrives on the forwarding connector.
+   overriding procedure Test_Arm_Command_On_Forward_Connector (Self : in out Instance);
    -- This unit test makes sure that an invalid command is handled gracefully.
    overriding procedure Test_Invalid_Command (Self : in out Instance);
 

--- a/src/components/command_protector/test/command_protector_tests-implementation.ads
+++ b/src/components/command_protector/test/command_protector_tests-implementation.ads
@@ -22,6 +22,8 @@ private
    overriding procedure Test_Protected_Command_Reject (Self : in out Instance);
    -- This unit test tests that a protected command is rejected if the component is unarmed due to timeout.
    overriding procedure Test_Protected_Command_Reject_Timeout (Self : in out Instance);
+   -- This unit test verifies that sending a second Arm command while already armed correctly resets the timeout.
+   overriding procedure Test_Rearm_While_Armed (Self : in out Instance);
    -- This unit test makes sure that an invalid command is handled gracefully.
    overriding procedure Test_Invalid_Command (Self : in out Instance);
 

--- a/src/components/command_protector/types/packed_arm_timeout.record.yaml
+++ b/src/components/command_protector/types/packed_arm_timeout.record.yaml
@@ -4,6 +4,6 @@ preamble: |
   type Arm_Timeout_Type is new Natural range 0 .. 255;
 fields:
   - name: Timeout
-    description: The timeout value (in ticks).
+    description: The timeout value (in ticks). A value of zero implies infinite timeout.
     type: Arm_Timeout_Type
     format: U8


### PR DESCRIPTION
Automated code review for `src/components/command_protector`.

## Findings: 5 issues (1 HIGH, 3 MEDIUM, 1 LOW)

### HIGH
- TOCTOU race on armed state between Get_State and Unarm calls

### MEDIUM
- Counter overflow wraps silently at Unsigned_16 max
- Misleading requirement text about arm command path
- Missing test for re-arming while already armed

### LOW
- Wrong comment in test (says 'not protected' for a protected command)

See `REVIEW.md` for details.