### PR TITLE
Code review: command_protector/arm_state

### DIFF
--- a/src/components/command_protector/arm_state/REVIEW.md
+++ b/src/components/command_protector/arm_state/REVIEW.md
@@ -140,3 +140,13 @@ No YAML models are present within the `arm_state/` directory itself. The depende
 | 3 | **Medium** | `Arm(0)` creates a stuck Armed state that never times out | `arm_state.adb:17–22` |
 | 4 | **Medium** | `Decrement_Timeout` silently ignores Armed state with zero timeout | `arm_state.adb:46–55` |
 | 5 | **Low** | `Unarm` assumes `Arm_Timeout_Type'First = 0` — fragile if type range changes | `arm_state.adb:31` |
+
+## Resolution Notes
+
+| # | Issue | Severity | Status | Commit | Notes |
+|---|-------|----------|--------|--------|-------|
+| 1 | Protected function with out parameter | High | Fixed | 4919d50 | Split into Get_State + Get_Timeout |
+| 2 | No unit tests | High | Fixed | 7844939 | Added 9 test cases |
+| 3 | Arm(0) creates stuck state | Medium | Fixed | 09accd3 | Guard rejects zero timeout |
+| 4 | Decrement_Timeout no-ops at zero | Medium | Fixed | 649d2ad | Forces Unarmed on zero timeout |
+| 5 | Fragile 'First usage | Low | Fixed | a0dac68 | Replaced with explicit 0 |

--- a/src/components/command_protector/arm_state/REVIEW.md
+++ b/src/components/command_protector/arm_state/REVIEW.md
@@ -1,0 +1,142 @@
+# Code Review: `Arm_State` Package
+
+**Reviewer:** Automated (Claude)
+**Date:** 2026-02-28
+**Branch:** `review/components-command-protector-arm-state`
+
+---
+
+## 1. Package Specification Review
+
+### Issue 1.1 — `Get_State` has an `out` parameter on a protected function
+
+- **File:** `arm_state.ads`, line 12
+- **Severity:** High
+- **Code:**
+  ```ada
+  function Get_State (The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) return Command_Protector_Enums.Armed_State.E;
+  ```
+- **Explanation:** In Ada, protected functions provide concurrent read access (multiple callers may execute simultaneously). However, `Get_State` has an `out` parameter, which means it modifies caller-visible state. While Ada 2012+ technically allows `out` parameters on functions, using one on a **protected function** is semantically misleading: callers expect a read-only lock, yet the function writes to `The_Timeout`. This compiles, but it undermines the concurrent-readers contract. If the intent is truly read-only, a separate function for the timeout would be clearer. If mutual exclusion is needed, this should be a procedure.
+- **Suggested fix:** Split into two protected functions, or change to a procedure:
+  ```ada
+  -- Option A: Two functions
+  function Get_State return Command_Protector_Enums.Armed_State.E;
+  function Get_Timeout return Packed_Arm_Timeout.Arm_Timeout_Type;
+
+  -- Option B: Procedure (gets exclusive lock)
+  procedure Get_State (The_State : out Command_Protector_Enums.Armed_State.E;
+                       The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type);
+  ```
+
+**No other specification issues found.** The private data is well-initialized with safe defaults (Unarmed, timeout = 0).
+
+---
+
+## 2. Package Implementation Review
+
+### Issue 2.1 — `Arm` does not validate zero timeout
+
+- **File:** `arm_state.adb`, lines 17–22
+- **Severity:** Medium
+- **Code:**
+  ```ada
+  procedure Arm (New_Timeout : in Packed_Arm_Timeout.Arm_Timeout_Type) is
+  begin
+     State := Command_Protector_Enums.Armed_State.Armed;
+     Timeout := New_Timeout;
+  end Arm;
+  ```
+- **Explanation:** If `New_Timeout` is 0 (`Arm_Timeout_Type'First`), the system transitions to `Armed` but with a zero timeout. On the next `Decrement_Timeout` call, the `Timeout > Arm_Timeout_Type'First` check is false, so the system stays `Armed` indefinitely — the timeout never fires and the state never returns to `Unarmed` via timeout. In a safety-critical command protector, an armed state that never times out could allow a protected command to be executed long after the operator intended.
+- **Suggested fix:**
+  ```ada
+  procedure Arm (New_Timeout : in Packed_Arm_Timeout.Arm_Timeout_Type) is
+  begin
+     -- Only arm if timeout is positive; a zero timeout is meaningless.
+     if New_Timeout > Packed_Arm_Timeout.Arm_Timeout_Type'First then
+        State := Command_Protector_Enums.Armed_State.Armed;
+        Timeout := New_Timeout;
+     end if;
+  end Arm;
+  ```
+  Alternatively, document that the caller is responsible for ensuring a non-zero timeout, and/or raise an event.
+
+### Issue 2.2 — `Decrement_Timeout` silently does nothing when Armed with zero timeout
+
+- **File:** `arm_state.adb`, lines 39–62
+- **Severity:** Medium (related to 2.1)
+- **Code:**
+  ```ada
+  when Armed =>
+     if Timeout > Arm_Timeout_Type'First then
+        Timeout := @ - 1;
+        if Timeout = Arm_Timeout_Type'First then
+           State := Command_Protector_Enums.Armed_State.Unarmed;
+           Timed_Out := True;
+        end if;
+     end if;
+  ```
+- **Explanation:** If the system is `Armed` and `Timeout` is already 0 (see Issue 2.1), this entire branch is skipped. The system reports `Timed_Out = False` and `New_State = Armed`, yet the timeout is 0. This is a stuck state that can only be exited via explicit `Unarm`. Combined with Issue 2.1, this creates a latent safety concern.
+- **Suggested fix:** Add an `else` clause to handle the already-zero case:
+  ```ada
+  if Timeout > Arm_Timeout_Type'First then
+     Timeout := @ - 1;
+     if Timeout = Arm_Timeout_Type'First then
+        State := Command_Protector_Enums.Armed_State.Unarmed;
+        Timed_Out := True;
+     end if;
+  else
+     -- Armed with zero timeout — force unarm as defensive measure
+     State := Command_Protector_Enums.Armed_State.Unarmed;
+     Timed_Out := True;
+  end if;
+  ```
+
+### Issue 2.3 — `Unarm` assumes `Arm_Timeout_Type'First` is zero
+
+- **File:** `arm_state.adb`, line 31
+- **Severity:** Low
+- **Code:**
+  ```ada
+  Timeout := Arm_Timeout_Type'First;
+  ```
+- **Explanation:** The comment says "Set the timeout to zero" but uses `'First`. Currently `Arm_Timeout_Type` is `0 .. 255` so `'First = 0`. If the range ever changes to start at a non-zero value, this would be incorrect. Using a named constant (e.g., `Arm_Timeout_Zero`) or an explicit literal `0` would be more robust, though the risk is low given the YAML-defined type.
+
+**No other implementation issues found.** The `case` statement covers all `Armed_State` literals explicitly, and the decrement uses `@ - 1` only after confirming the value is positive, preventing underflow.
+
+---
+
+## 3. Model Review
+
+No YAML models are present within the `arm_state/` directory itself. The dependent types (`Packed_Arm_Timeout`, `Command_Protector_Enums`) are defined in `../types/` and are outside the scope of this package review. They were consulted for context only.
+
+---
+
+## 4. Unit Test Review
+
+**No unit tests found.** There is no `test/` subdirectory under `arm_state/`.
+
+### Issue 4.1 — Missing unit tests
+
+- **Severity:** High
+- **Explanation:** This is a safety-critical protected object managing arm/disarm state with timeout logic. The following scenarios should be tested:
+  1. Initial state is `Unarmed` with timeout = 0.
+  2. `Arm` transitions to `Armed` with correct timeout.
+  3. `Unarm` transitions to `Unarmed` and resets timeout.
+  4. `Decrement_Timeout` counts down correctly and transitions to `Unarmed` at zero.
+  5. `Decrement_Timeout` when already `Unarmed` is a no-op.
+  6. **Edge case:** `Arm` with timeout = 0 (exposes Issue 2.1).
+  7. **Edge case:** `Arm` with timeout = 1 (immediate timeout on first decrement).
+  8. **Edge case:** `Arm` with timeout = 255 (`Arm_Timeout_Type'Last`).
+  9. Re-arming while already armed resets the timeout.
+
+---
+
+## 5. Summary — Top 5 Highest-Severity Findings
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 1 | **High** | `Get_State` is a protected function with `out` parameter — misleading concurrency semantics | `arm_state.ads:12` |
+| 2 | **High** | No unit tests for safety-critical arm/timeout logic | `arm_state/` (missing test dir) |
+| 3 | **Medium** | `Arm(0)` creates a stuck Armed state that never times out | `arm_state.adb:17–22` |
+| 4 | **Medium** | `Decrement_Timeout` silently ignores Armed state with zero timeout | `arm_state.adb:46–55` |
+| 5 | **Low** | `Unarm` assumes `Arm_Timeout_Type'First = 0` — fragile if type range changes | `arm_state.adb:31` |

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -5,11 +5,15 @@ package body Arm_State is
       --
       -- Functions that provide read-only access to the private data:
       --
-      function Get_State (The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) return Command_Protector_Enums.Armed_State.E is
+      function Get_State return Command_Protector_Enums.Armed_State.E is
       begin
-         The_Timeout := Timeout;
          return State;
       end Get_State;
+
+      function Get_Timeout return Packed_Arm_Timeout.Arm_Timeout_Type is
+      begin
+         return Timeout;
+      end Get_Timeout;
 
       --
       -- Procedures requiring full mutual exclusion:

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -39,7 +39,7 @@ package body Arm_State is
          -- Unarm the system
          State := Command_Protector_Enums.Armed_State.Unarmed;
          -- Set the timeout to zero:
-         Timeout := Arm_Timeout_Type'First;
+         Timeout := 0;
       end Unarm;
 
       -- Decrement the timeout, and transition to the unarmed state if the

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -20,11 +20,16 @@ package body Arm_State is
       --
       -- Arm the system and provide a timeout value:
       procedure Arm (New_Timeout : in Packed_Arm_Timeout.Arm_Timeout_Type) is
+         use Packed_Arm_Timeout;
       begin
-         -- Arm the system
-         State := Command_Protector_Enums.Armed_State.Armed;
-         -- Set the timeout:
-         Timeout := New_Timeout;
+         -- Only arm if timeout is positive; a zero timeout is meaningless
+         -- and would create a stuck Armed state that never times out.
+         if New_Timeout > Arm_Timeout_Type'First then
+            -- Arm the system
+            State := Command_Protector_Enums.Armed_State.Armed;
+            -- Set the timeout:
+            Timeout := New_Timeout;
+         end if;
       end Arm;
 
       -- Unarm the system and cancel the timeout:

--- a/src/components/command_protector/arm_state/arm_state.adb
+++ b/src/components/command_protector/arm_state/arm_state.adb
@@ -66,6 +66,11 @@ package body Arm_State is
                      State := Command_Protector_Enums.Armed_State.Unarmed;
                      Timed_Out := True;
                   end if;
+               else
+                  -- Armed with zero timeout — defensive measure to prevent
+                  -- a stuck Armed state. Force transition to Unarmed.
+                  State := Command_Protector_Enums.Armed_State.Unarmed;
+                  Timed_Out := True;
                end if;
 
             when Unarmed =>

--- a/src/components/command_protector/arm_state/arm_state.ads
+++ b/src/components/command_protector/arm_state/arm_state.ads
@@ -10,7 +10,8 @@ package Arm_State is
       --
       -- Functions that provide read-only access to the private data:
       --
-      function Get_State (The_Timeout : out Packed_Arm_Timeout.Arm_Timeout_Type) return Command_Protector_Enums.Armed_State.E;
+      function Get_State return Command_Protector_Enums.Armed_State.E;
+      function Get_Timeout return Packed_Arm_Timeout.Arm_Timeout_Type;
 
       --
       -- Procedures requiring full mutual exclusion:

--- a/src/components/command_protector/arm_state/test/arm_state.tests.yaml
+++ b/src/components/command_protector/arm_state/test/arm_state.tests.yaml
@@ -1,0 +1,21 @@
+---
+description: Unit tests for the Arm_State protected type
+tests:
+  - name: Test_Initial_State
+    description: Verify initial state is Unarmed with timeout of zero.
+  - name: Test_Arm_And_Get_State
+    description: Verify Arm transitions to Armed with correct timeout.
+  - name: Test_Unarm
+    description: Verify Unarm transitions to Unarmed and resets timeout.
+  - name: Test_Decrement_Timeout
+    description: Verify Decrement_Timeout counts down and transitions to Unarmed at zero.
+  - name: Test_Decrement_When_Unarmed
+    description: Verify Decrement_Timeout is a no-op when Unarmed.
+  - name: Test_Arm_With_Zero_Timeout
+    description: Verify Arm with timeout of zero is rejected (stays Unarmed).
+  - name: Test_Arm_With_Timeout_One
+    description: Verify Arm with timeout of 1 transitions to Unarmed on first decrement.
+  - name: Test_Arm_With_Max_Timeout
+    description: Verify Arm with maximum timeout value works correctly.
+  - name: Test_Rearm_While_Armed
+    description: Verify re-arming while armed resets the timeout.

--- a/src/components/command_protector/arm_state/test/arm_state_tests-implementation.adb
+++ b/src/components/command_protector/arm_state/test/arm_state_tests-implementation.adb
@@ -1,0 +1,179 @@
+--------------------------------------------------------------------------------
+-- Arm_State Tests Body
+--------------------------------------------------------------------------------
+
+with Arm_State;
+with Command_Protector_Enums;
+with Packed_Arm_Timeout;
+with Smart_Assert;
+
+package body Arm_State_Tests.Implementation is
+
+   -------------------------------------------------------------------------
+   -- Fixtures:
+   -------------------------------------------------------------------------
+
+   overriding procedure Set_Up_Test (Self : in out Instance) is
+   begin
+      null;
+   end Set_Up_Test;
+
+   overriding procedure Tear_Down_Test (Self : in out Instance) is
+   begin
+      null;
+   end Tear_Down_Test;
+
+   -------------------------------------------------------------------------
+   -- Assertion packages:
+   -------------------------------------------------------------------------
+   package State_Assert is new Smart_Assert.Discrete (Command_Protector_Enums.Armed_State.E, Command_Protector_Enums.Armed_State.E'Image);
+   package Timeout_Assert is new Smart_Assert.Discrete (Packed_Arm_Timeout.Arm_Timeout_Type, Packed_Arm_Timeout.Arm_Timeout_Type'Image);
+   package Bool_Assert is new Smart_Assert.Discrete (Boolean, Boolean'Image);
+
+   -------------------------------------------------------------------------
+   -- Tests:
+   -------------------------------------------------------------------------
+
+   overriding procedure Test_Initial_State (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+   begin
+      -- Initial state should be Unarmed with zero timeout:
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 0);
+   end Test_Initial_State;
+
+   overriding procedure Test_Arm_And_Get_State (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+   begin
+      -- Arm with timeout of 10:
+      Obj.Arm (10);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 10);
+   end Test_Arm_And_Get_State;
+
+   overriding procedure Test_Unarm (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+   begin
+      -- Arm then unarm:
+      Obj.Arm (50);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+      Obj.Unarm;
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 0);
+   end Test_Unarm;
+
+   overriding procedure Test_Decrement_Timeout (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+      Timeout_Val : Packed_Arm_Timeout.Arm_Timeout_Type;
+      New_State : Command_Protector_Enums.Armed_State.E;
+      Timed_Out : Boolean;
+   begin
+      -- Arm with timeout of 3:
+      Obj.Arm (3);
+
+      -- Decrement 1: timeout should be 2, still armed
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 2);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Armed);
+      Bool_Assert.Eq (Timed_Out, False);
+
+      -- Decrement 2: timeout should be 1, still armed
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 1);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Armed);
+      Bool_Assert.Eq (Timed_Out, False);
+
+      -- Decrement 3: timeout should be 0, now unarmed, timed out
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 0);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Bool_Assert.Eq (Timed_Out, True);
+
+      -- Decrement again: should be no-op since unarmed
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 0);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Bool_Assert.Eq (Timed_Out, False);
+   end Test_Decrement_Timeout;
+
+   overriding procedure Test_Decrement_When_Unarmed (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+      Timeout_Val : Packed_Arm_Timeout.Arm_Timeout_Type;
+      New_State : Command_Protector_Enums.Armed_State.E;
+      Timed_Out : Boolean;
+   begin
+      -- Decrement when unarmed should be a no-op:
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 0);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Bool_Assert.Eq (Timed_Out, False);
+   end Test_Decrement_When_Unarmed;
+
+   overriding procedure Test_Arm_With_Zero_Timeout (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+   begin
+      -- Arm with zero timeout should be rejected (stays Unarmed):
+      Obj.Arm (0);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 0);
+   end Test_Arm_With_Zero_Timeout;
+
+   overriding procedure Test_Arm_With_Timeout_One (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+      Timeout_Val : Packed_Arm_Timeout.Arm_Timeout_Type;
+      New_State : Command_Protector_Enums.Armed_State.E;
+      Timed_Out : Boolean;
+   begin
+      -- Arm with timeout of 1:
+      Obj.Arm (1);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 1);
+
+      -- First decrement should cause timeout:
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 0);
+      State_Assert.Eq (New_State, Command_Protector_Enums.Armed_State.Unarmed);
+      Bool_Assert.Eq (Timed_Out, True);
+   end Test_Arm_With_Timeout_One;
+
+   overriding procedure Test_Arm_With_Max_Timeout (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+      use Packed_Arm_Timeout;
+   begin
+      -- Arm with max timeout:
+      Obj.Arm (Arm_Timeout_Type'Last);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, Arm_Timeout_Type'Last);
+   end Test_Arm_With_Max_Timeout;
+
+   overriding procedure Test_Rearm_While_Armed (Self : in out Instance) is
+      Ignore_Self : Instance renames Self;
+      Obj : Arm_State.Protected_Arm_State;
+      Timeout_Val : Packed_Arm_Timeout.Arm_Timeout_Type;
+      New_State : Command_Protector_Enums.Armed_State.E;
+      Timed_Out : Boolean;
+   begin
+      -- Arm with timeout of 5:
+      Obj.Arm (5);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+
+      -- Decrement twice:
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Obj.Decrement_Timeout (Timeout_Val, New_State, Timed_Out);
+      Timeout_Assert.Eq (Timeout_Val, 3);
+
+      -- Re-arm with timeout of 10:
+      Obj.Arm (10);
+      State_Assert.Eq (Obj.Get_State, Command_Protector_Enums.Armed_State.Armed);
+      Timeout_Assert.Eq (Obj.Get_Timeout, 10);
+   end Test_Rearm_While_Armed;
+
+end Arm_State_Tests.Implementation;

--- a/src/components/command_protector/arm_state/test/arm_state_tests-implementation.ads
+++ b/src/components/command_protector/arm_state/test/arm_state_tests-implementation.ads
@@ -1,0 +1,38 @@
+--------------------------------------------------------------------------------
+-- Arm_State Tests Spec
+--------------------------------------------------------------------------------
+
+-- Unit tests for the Arm_State protected type
+package Arm_State_Tests.Implementation is
+   -- Test data and state:
+   type Instance is new Arm_State_Tests.Base_Instance with private;
+   type Class_Access is access all Instance'Class;
+private
+   -- Fixture procedures:
+   overriding procedure Set_Up_Test (Self : in out Instance);
+   overriding procedure Tear_Down_Test (Self : in out Instance);
+
+   -- Verify initial state is Unarmed with timeout of zero.
+   overriding procedure Test_Initial_State (Self : in out Instance);
+   -- Verify Arm transitions to Armed with correct timeout.
+   overriding procedure Test_Arm_And_Get_State (Self : in out Instance);
+   -- Verify Unarm transitions to Unarmed and resets timeout.
+   overriding procedure Test_Unarm (Self : in out Instance);
+   -- Verify Decrement_Timeout counts down and transitions to Unarmed at zero.
+   overriding procedure Test_Decrement_Timeout (Self : in out Instance);
+   -- Verify Decrement_Timeout is a no-op when Unarmed.
+   overriding procedure Test_Decrement_When_Unarmed (Self : in out Instance);
+   -- Verify Arm with timeout of zero is rejected (stays Unarmed).
+   overriding procedure Test_Arm_With_Zero_Timeout (Self : in out Instance);
+   -- Verify Arm with timeout of 1 transitions to Unarmed on first decrement.
+   overriding procedure Test_Arm_With_Timeout_One (Self : in out Instance);
+   -- Verify Arm with maximum timeout value works correctly.
+   overriding procedure Test_Arm_With_Max_Timeout (Self : in out Instance);
+   -- Verify re-arming while armed resets the timeout.
+   overriding procedure Test_Rearm_While_Armed (Self : in out Instance);
+
+   -- Test data and state:
+   type Instance is new Arm_State_Tests.Base_Instance with record
+      null;
+   end record;
+end Arm_State_Tests.Implementation;

--- a/src/components/command_protector/arm_state/test/env.py
+++ b/src/components/command_protector/arm_state/test/env.py
@@ -1,0 +1,1 @@
+from environments import test  # noqa: F401

--- a/src/components/command_protector/arm_state/test/test.adb
+++ b/src/components/command_protector/arm_state/test/test.adb
@@ -1,0 +1,23 @@
+--------------------------------------------------------------------------------
+-- Arm_State Tests
+--------------------------------------------------------------------------------
+
+with AUnit.Reporter.Text;
+with AUnit.Run;
+with Arm_State_Tests.Implementation.Suite;
+-- Make sure any terminating tasks are handled and an appropriate
+-- error message is printed.
+with Unit_Test_Termination_Handler;
+pragma Unreferenced (Unit_Test_Termination_Handler);
+
+procedure Test is
+   -- Create runner for test suite:
+   procedure Runner is new AUnit.Run.Test_Runner (Arm_State_Tests.Implementation.Suite.Get);
+   -- Use the text reporter:
+   Reporter : AUnit.Reporter.Text.Text_Reporter;
+begin
+   -- Add color output to test run:
+   AUnit.Reporter.Text.Set_Use_ANSI_Colors (Reporter, True);
+   -- Run tests:
+   Runner (Reporter);
+end Test;

--- a/src/components/command_protector/component-command_protector-implementation.adb
+++ b/src/components/command_protector/component-command_protector-implementation.adb
@@ -50,8 +50,8 @@ package body Component.Command_Protector.Implementation is
    -- Send out data products:
    overriding procedure Set_Up (Self : in out Instance) is
       The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-      Start_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Start_Timeout);
+      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+      Start_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
    begin
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => Start_State)));
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => Start_Timeout)));
@@ -99,8 +99,7 @@ package body Component.Command_Protector.Implementation is
    overriding procedure Command_T_To_Forward_Recv_Sync (Self : in out Instance; Arg : in Command.T) is
       use Command_Protector_Enums.Armed_State;
       -- Get the armed state:
-      Ignore_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-      State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Ignore_Timeout);
+      State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
       -- Look up to see if this command is in the protected list:
       Id_To_Find : Command_Id renames Arg.Header.Id;
       Ignore_Found_Id : Command_Id;
@@ -120,8 +119,8 @@ package body Component.Command_Protector.Implementation is
 
             declare
                -- Get the new state:
-               New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-               New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+               New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+               New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
                -- Timestamp:
                The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
             begin
@@ -202,8 +201,8 @@ package body Component.Command_Protector.Implementation is
       -- Send out data products and events:
       declare
          The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-         New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+         New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
       begin
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => New_Timeout)));

--- a/src/components/memory_stuffer/component-memory_stuffer-implementation.adb
+++ b/src/components/memory_stuffer/component-memory_stuffer-implementation.adb
@@ -35,8 +35,8 @@ package body Component.Memory_Stuffer.Implementation is
 
    overriding procedure Set_Up (Self : in out Instance) is
       The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-      Start_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Start_Timeout);
+      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+      Start_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
    begin
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => Start_State)));
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => Start_Timeout)));
@@ -121,8 +121,8 @@ package body Component.Memory_Stuffer.Implementation is
 
       declare
          -- Get the new state:
-         New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+         New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
       begin
          -- Send new armed data product:
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
@@ -148,8 +148,8 @@ package body Component.Memory_Stuffer.Implementation is
       -- Send out data products and events:
       declare
          The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-         New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+         New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
       begin
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => New_Timeout)));
@@ -174,8 +174,7 @@ package body Component.Memory_Stuffer.Implementation is
       declare
          use Command_Protector_Enums.Armed_State;
          -- Get the armed state:
-         Ignore_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Ignore_Timeout);
+         State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
       begin
          -- Based on the arm/unarmed state we do things differently.
          case State is

--- a/src/components/register_stuffer/component-register_stuffer-implementation.adb
+++ b/src/components/register_stuffer/component-register_stuffer-implementation.adb
@@ -29,8 +29,8 @@ package body Component.Register_Stuffer.Implementation is
 
    overriding procedure Set_Up (Self : in out Instance) is
       The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-      Start_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Start_Timeout);
+      Start_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+      Start_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
    begin
       if Self.Protect_Registers then
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => Start_State)));
@@ -121,8 +121,8 @@ package body Component.Register_Stuffer.Implementation is
 
       declare
          -- Get the new state:
-         New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+         New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
       begin
          -- Send new armed data product:
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
@@ -149,8 +149,7 @@ package body Component.Register_Stuffer.Implementation is
          declare
             use Command_Protector_Enums.Armed_State;
             -- Get the armed state:
-            Ignore_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-            State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (Ignore_Timeout);
+            State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
          begin
             -- Based on the arm/unarmed state we do things differently.
             case State is
@@ -229,8 +228,8 @@ package body Component.Register_Stuffer.Implementation is
       -- Send out data products and events:
       declare
          The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
-         New_Timeout : Packed_Arm_Timeout.Arm_Timeout_Type;
-         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State (New_Timeout);
+         New_State : constant Command_Protector_Enums.Armed_State.E := Self.Command_Arm_State.Get_State;
+         New_Timeout : constant Packed_Arm_Timeout.Arm_Timeout_Type := Self.Command_Arm_State.Get_Timeout;
       begin
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State (The_Time, (State => New_State)));
          Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Armed_State_Timeout (The_Time, (Timeout => New_Timeout)));


### PR DESCRIPTION
Automated code review for `src/components/command_protector/arm_state`.

## Findings: 5 issues (2 HIGH, 2 MEDIUM, 1 LOW)

### HIGH
- Protected function with out parameter undermines concurrent-readers contract
- No unit tests for safety-critical package

### MEDIUM
- Arm(0) creates stuck armed state that never expires
- Decrement_Timeout silently no-ops at zero timeout

### LOW
- Fragile use of 'First with comment saying "zero"

See `REVIEW.md` for details.