### PR TITLE
Code review: fault_correction/gen/templates/fault_responses

### DIFF
--- a/src/components/fault_correction/gen/templates/fault_responses/REVIEW.md
+++ b/src/components/fault_correction/gen/templates/fault_responses/REVIEW.md
@@ -1,0 +1,166 @@
+# Code Review: fault_responses Template Package
+
+**Package:** `fault_responses` (Jinja2-generated non-component package)
+**Branch:** `review/components-fault-correction-gen-templates-fault-responses`
+**Date:** 2026-02-28
+**Reviewer:** Automated Ada Code Review
+
+---
+
+## 1. Package Specification Review (`name.ads`)
+
+### Issue 1.1 — Unconditional `use` Clauses at Library Level
+
+- **Location:** `name.ads`, lines 5–6
+- **Original Code:**
+  ```ada
+  with Fault_Correction_Enums; use Fault_Correction_Enums.Startup_Status_Type; use Fault_Correction_Enums.Latching_Type;
+  ```
+- **Explanation:** Library-level `use` clauses on enumeration packages make all enumeration literals (e.g., `Enabled`, `Disabled`, `Latching`, `Non_Latching`) directly visible to any package that `with`s this generated package. In safety-critical flight code, this pollutes the namespace of downstream consumers and risks silent ambiguity if another `use`d package defines literals with the same names (e.g., `Enabled`/`Disabled` are extremely common). The `use` is only needed for convenience within the aggregate initializers below and should be scoped locally or removed in favor of fully qualified names.
+- **Corrected Code:**
+  ```ada
+  with Fault_Correction_Enums;
+  ```
+  Then use fully qualified names in the record aggregates: `Fault_Correction_Enums.Latching_Type.Latching`, `Fault_Correction_Enums.Startup_Status_Type.Enabled`, etc. Alternatively, if the generator insists on short names, place `use` clauses inside a nested declarative region.
+- **Severity:** **Medium** — Namespace pollution in safety-critical code; potential for silent enumeration literal ambiguity in downstream units.
+
+### Issue 1.2 — Conditional `with Basic_Types; use Basic_Types` Only Guarded by `has_command_args`
+
+- **Location:** `name.ads`, lines 3–4
+  ```ada
+  {% if has_command_args %}
+  with Basic_Types; use Basic_Types;
+  with Command_Types;
+  {% endif %}
+  ```
+- **Explanation:** The `use Basic_Types` is a library-level `use` clause that makes all of `Basic_Types` visible. Same namespace-pollution concern as Issue 1.1. Additionally, `Command_Types` is `with`'d but the spec body only references `Command_Types.Command_Arg_Buffer_Type` inside a Jinja branch — if the generator logic for `has_command_args` diverges from the per-response `response.command.type_model` check, the `with` could be present but unused, or absent when needed. These two guards should be unified or the `with` made unconditional.
+- **Corrected Code:**
+  ```ada
+  {% if has_command_args %}
+  with Basic_Types;
+  with Command_Types;
+  {% endif %}
+  ```
+  (Drop the `use Basic_Types` — it's not needed in the generated output since `Byte_Array` is only referenced through the serialization call, which is fully qualified.)
+- **Severity:** **Low** — Unnecessary `use` clause; minor maintainability concern on guard consistency.
+
+### Issue 1.3 — `Source_Id => 0` Hardcoded Magic Number
+
+- **Location:** `name.ads`, inside the command response aggregate
+  ```ada
+  Source_Id => 0,
+  ```
+- **Explanation:** The command source ID is hardcoded to `0` for every fault response. In a multi-source command architecture, source ID `0` may be a valid, meaningful source or it may be reserved as "unset." This should be a named constant (e.g., `Fault_Correction_Source_Id`) or a configurable template parameter so operators and reviewers can verify the intended command source. Hardcoded magic numbers in safety-critical command dispatch paths are a risk.
+- **Corrected Code:**
+  ```ada
+  Source_Id => {{ response.source_id | default("0") }},
+  ```
+  Or define a constant in the package:
+  ```ada
+  Fault_Correction_Source_Id : constant := 0;
+  ```
+- **Severity:** **Medium** — Magic number in command dispatch path; reduces traceability and configurability.
+
+### Issue 1.4 — Arg_Buffer Padding Expression Relies on Exact Size Arithmetic
+
+- **Location:** `name.ads`, command arg buffer construction
+  ```ada
+  {{ response.command_arg_type_model.name }}.Serialization.To_Byte_Array ({{ response.command_arg }}) &
+  [0 .. Command_Types.Command_Arg_Buffer_Type'Length - {{ response.command_arg_type_model.name }}.Size_In_Bytes - 1 => 0]
+  ```
+- **Explanation:** If `Size_In_Bytes` equals `Command_Arg_Buffer_Type'Length`, the range becomes `[0 .. -1 => 0]` which is a null range and legal Ada — this is fine. However, if a generator bug or model misconfiguration causes `Size_In_Bytes` to *exceed* the buffer length, this produces a range with `'Last < 'First` by wrapping (still null range due to Natural semantics), but the concatenation result will exceed `Command_Arg_Buffer_Type'Length`, causing a `Constraint_Error` at elaboration time. Since these are `constant` declarations elaborated at startup, a misconfiguration would crash the flight software during initialization rather than being caught at code-generation time. The generator should validate `Size_In_Bytes <= Command_Arg_Buffer_Type'Length` and emit an error.
+- **Corrected Code (generator-side validation):**
+  ```python
+  assert response.command_arg_type_model.size_in_bytes <= command_buffer_size, \
+      f"Command arg for {response.full_fault_name} exceeds buffer size"
+  ```
+- **Severity:** **High** — Unchecked arithmetic could cause elaboration-time crash in flight software if model is misconfigured.
+
+---
+
+## 2. Package Implementation Review
+
+This is a pure specification package (no `.adb` body). All declarations are constants and types — no implementation file exists or is needed.
+
+**No issues identified** — the absence of a body is correct for a package containing only constant declarations.
+
+---
+
+## 3. Model Review
+
+### Issue 3.1 — `name_enums.enums.yaml`: Fault_Type Enumeration Uses `E16` in Packed ID but Enum Has No Explicit Size Constraint
+
+- **Location:** `name_packed_id_type.record.yaml`
+  ```yaml
+  format: E16
+  ```
+  Combined with `name_enums.enums.yaml` which defines `Fault_Type` with explicit values starting at 0.
+- **Explanation:** The packed ID type uses `E16` (16-bit enumeration) format. If the number of fault responses exceeds 65,535 unique IDs, the 16-bit representation will overflow. While unlikely in practice, the `Fault_Type` enumeration's `value` fields are set by `{{ response.fault_id }}` with no documented upper-bound validation in the template. The `Fault_Types.Fault_Id` used in the Ada record is also unbounded in the template. The generator should validate that all fault IDs fit in 16 bits.
+- **Corrected Code (generator-side):**
+  ```python
+  assert response.fault_id <= 65535, f"Fault ID {response.fault_id} exceeds 16-bit range"
+  ```
+- **Severity:** **Medium** — Missing generator-side range validation for fault IDs against the packed representation size.
+
+### Issue 3.2 — `name_status_record.record.yaml`: Padding Logic Assumes 2-bit Status Fields
+
+- **Location:** `name_status_record.record.yaml`
+  ```yaml
+  format: E2
+  ...
+  {% if ((responses|length) % 4) != 0 %}
+  {% for idx in range(4 - ((responses|length) % 4)) %}
+  ```
+- **Explanation:** The padding calculation `(responses|length) % 4` correctly accounts for 2-bit fields needing to align to a byte boundary (4 × 2 bits = 8 bits = 1 byte). The `Status_Type` enum has 4 values (0–3) fitting in 2 bits (`E2`). This is correct. However, if `Status_Type` ever gains a 5th value, the `E2` format becomes insufficient, and the padding math breaks silently. A comment in the template documenting this coupling would improve maintainability.
+- **Corrected Code:** Add a comment:
+  ```yaml
+  # NOTE: Padding assumes Status_Type fits in 2 bits (E2). If Status_Type grows
+  # beyond 4 values, both the format and padding calculation must be updated.
+  ```
+- **Severity:** **Low** — Implicit coupling between enum size and padding math; documentation gap.
+
+### Issue 3.3 — `name_enums.enums.yaml`: Missing Description Guard Generates Blank Lines
+
+- **Location:** `name_enums.enums.yaml`
+  ```yaml
+  {% if response.description %}
+        description: "{{ response.description }}"
+  {% endif %}
+  ```
+- **Explanation:** When `response.description` is `None`/empty, the `{% if %}` block is skipped but the Jinja whitespace handling may leave blank lines in the YAML output depending on the Jinja environment's `trim_blocks`/`lstrip_blocks` settings. While typically harmless for YAML parsers, inconsistent blank lines in generated YAML can cause diff noise and confuse downstream tooling. Using Jinja whitespace-control markers (`{%-`, `-%}`) would produce cleaner output.
+- **Corrected Code:**
+  ```yaml
+  {%- if response.description %}
+        description: "{{ response.description }}"
+  {%- endif %}
+  ```
+- **Severity:** **Low** — Cosmetic; potential diff noise in generated artifacts.
+
+---
+
+## 4. Unit Test Review
+
+**No unit test files found** in this directory or its subdirectories.
+
+This is a template-only package — the generated output is tested as part of the consuming component's test suite (the `fault_correction` component). The templates themselves contain no executable Ada logic beyond constant initialization, so unit testing at this level would test the *generator*, not the template.
+
+**Recommendation:** Ensure the generator's test suite covers:
+- Zero responses (empty list) — produces a null array `Fault_Response_List`
+- Single response with and without command args
+- Responses where `Size_In_Bytes` equals `Command_Arg_Buffer_Type'Length` (no padding needed)
+- Maximum fault ID values near the 16-bit boundary
+- Description fields containing YAML-special characters (colons, quotes, newlines)
+
+- **Severity:** **Low** — Testing responsibility lies with the generator, not the template directory.
+
+---
+
+## 5. Summary — Top 5 Issues
+
+| # | Severity | Location | Issue |
+|---|----------|----------|-------|
+| 1 | **High** | `name.ads` — Arg_Buffer padding | Unchecked size arithmetic could cause elaboration-time `Constraint_Error` if command arg size exceeds buffer length. Generator must validate. |
+| 2 | **Medium** | `name.ads` — `Source_Id => 0` | Hardcoded magic number for command source ID reduces traceability and configurability in command dispatch. |
+| 3 | **Medium** | `name.ads` — library-level `use` clauses | `use Fault_Correction_Enums.*` at library level pollutes namespace of all downstream consumers; risk of literal ambiguity. |
+| 4 | **Medium** | `name_packed_id_type.record.yaml` / `name_enums.enums.yaml` | No generator-side validation that fault IDs fit within the 16-bit packed representation. |
+| 5 | **Low** | `name_status_record.record.yaml` | Implicit coupling between `Status_Type` size (2 bits) and padding arithmetic; undocumented. |


### PR DESCRIPTION
Review-only. See `REVIEW.md`.