### PR TITLE
Code review: src/components/limiter

### DIFF
--- a/src/components/limiter/REVIEW.md
+++ b/src/components/limiter/REVIEW.md
@@ -1,0 +1,273 @@
+# Limiter Component Code Review
+
+**Reviewer:** Automated Safety-Critical Code Review  
+**Date:** 2026-02-28  
+**Branch:** review/components-limiter
+
+---
+
+## 1. Documentation Review
+
+### Issue 1.1 — Missing Data Products Section in LaTeX Document (Low)
+
+**Location:** `doc/limiter.tex`, line ~30
+
+**Original Code:**
+```latex
+\subsection{Parameters}
+
+\input{build/tex/limiter_parameters.tex}
+
+\subsection{Events}
+
+\input{build/tex/limiter_events.tex}
+
+\section{Unit Tests}
+```
+
+**Explanation:** The document includes Commands, Parameters, and Events subsections under Design, and the Data Products section is present in the component YAML but there is no `\subsection{Data Products}` in the LaTeX document between Parameters and Events (or after Events). Users consulting the generated PDF will not find documentation of the `Max_Packet_Sends_Per_Tick` data product in the Design section.
+
+**Corrected Code:**
+```latex
+\subsection{Parameters}
+
+\input{build/tex/limiter_parameters.tex}
+
+\subsection{Data Products}
+
+\input{build/tex/limiter_data_products.tex}
+
+\subsection{Events}
+
+\input{build/tex/limiter_events.tex}
+
+\section{Unit Tests}
+```
+
+**Severity:** Low
+
+---
+
+### Issue 1.2 — Inconsistent Naming: "Send" vs "Sends" (Low)
+
+**Location:** `limiter.events.yaml`, line 3; also `component-limiter-implementation.adb` line ~96
+
+**Original Code (events.yaml):**
+```yaml
+  - name: Max_Send_Per_Tick_Set
+```
+
+**Explanation:** The event is named `Max_Send_Per_Tick_Set` (singular "Send"), while the command is `Sends_Per_Tick` (plural), the parameter is `Max_Sends_Per_Tick` (plural), and the data product is `Max_Packet_Sends_Per_Tick` (plural). This inconsistency could confuse operators correlating telemetry events with commands/parameters.
+
+**Corrected Code:**
+```yaml
+  - name: Max_Sends_Per_Tick_Set
+```
+
+(With corresponding updates to all references in the implementation and test code.)
+
+**Severity:** Low
+
+---
+
+## 2. Model Review
+
+### Issue 2.1 — Parameter Default Does Not Match Init Default (Medium)
+
+**Location:** `limiter.parameters.yaml`, line 7
+
+**Original Code:**
+```yaml
+    default: "(Value => 1)"
+```
+
+**Explanation:** The parameter default for `Max_Sends_Per_Tick` is `1`, but the test suite initializes the component with `Max_Sends_Per_Tick => 3`. While the parameter default and the init value are independent concepts (the init value seeds the protected variable, and the parameter default is the table's reset value), if a parameter update is issued without first staging a value, the component would revert to a rate of 1 rather than the init value. This mismatch between the parameter table default and common init values is a potential source of confusion for integrators. The design should document why these differ or unify them.
+
+**Severity:** Medium
+
+---
+
+### Issue 2.2 — No Requirement for Queue Overflow Behavior (Low)
+
+**Location:** `limiter.requirements.yaml`
+
+**Original Code:**
+```yaml
+requirements:
+  - text: The component shall be able to receive and queue a generic data type.
+  - text: The component shall send queued data at a configurable periodic rate.
+  - text: The rate at which queued data is sent shall be configurable by command.
+  - text: The rate at which queued data is sent shall be configurable by parameter.
+```
+
+**Explanation:** There is no requirement covering the queue-full/overflow behavior (i.e., that the component shall emit a `Data_Dropped` event when the queue overflows). The test suite explicitly tests this behavior in `Test_Queue_Overflow`, but it is not traceable to a requirement.
+
+**Corrected Code:**
+```yaml
+  - text: The component shall emit an event when incoming data is dropped due to a full queue.
+```
+
+**Severity:** Low
+
+---
+
+## 3. Component Implementation Review
+
+### Issue 3.1 — Command Does Not Update Parameter Table (Causes Command/Parameter Desynchronization) (High)
+
+**Location:** `component-limiter-implementation.adb`, `Sends_Per_Tick` function (line ~88–99)
+
+**Original Code:**
+```ada
+   overriding function Sends_Per_Tick (Self : in out Instance; Arg : in Packed_U16.T) return Command_Execution_Status.E is
+      use Command_Execution_Status;
+      The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
+   begin
+      -- Set the rate:
+      Self.P_Max_Sends_Per_Tick.Set_Var (Arg.Value);
+      -- Send data product:
+      Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Max_Packet_Sends_Per_Tick (The_Time, (Value => Self.P_Max_Sends_Per_Tick.Get_Var)));
+      -- Send event:
+      Self.Event_T_Send_If_Connected (Self.Events.Max_Send_Per_Tick_Set (The_Time, Arg));
+      return Success;
+   end Sends_Per_Tick;
+```
+
+**Explanation:** When the `Sends_Per_Tick` command is received, only the protected variable `P_Max_Sends_Per_Tick` is updated. The component's parameter table (`Self.Max_Sends_Per_Tick`) is **not** updated. This means:
+
+1. A subsequent `Fetch` parameter operation will return the **old** (stale) parameter value, not the value set by command.
+2. If `Update_Parameters` is called on the next tick (via `Self.Update_Parameters` in `Tick_T_Recv_Sync`), and no new parameter was staged, the parameter table value will overwrite the command-set value back to whatever was previously in the table.
+
+This is a **silent reversion** of the commanded rate on the very next tick. The tick handler calls `Self.Update_Parameters` unconditionally, which calls `Update_Parameters_Action`, which copies `Self.Max_Sends_Per_Tick.Value` (the parameter table) back into `P_Max_Sends_Per_Tick` — undoing the command.
+
+**Corrected Code:**
+```ada
+   overriding function Sends_Per_Tick (Self : in out Instance; Arg : in Packed_U16.T) return Command_Execution_Status.E is
+      use Command_Execution_Status;
+      The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
+   begin
+      -- Set the rate in both the protected variable and the parameter table
+      -- so that they stay in sync:
+      Self.P_Max_Sends_Per_Tick.Set_Var (Arg.Value);
+      Self.Max_Sends_Per_Tick := (Value => Arg.Value);
+      -- Send data product:
+      Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Max_Packet_Sends_Per_Tick (The_Time, (Value => Self.P_Max_Sends_Per_Tick.Get_Var)));
+      -- Send event:
+      Self.Event_T_Send_If_Connected (Self.Events.Max_Send_Per_Tick_Set (The_Time, Arg));
+      return Success;
+   end Sends_Per_Tick;
+```
+
+*Alternatively*, the `Tick_T_Recv_Sync` should only call `Self.Update_Parameters` when a parameter update is actually pending, or `Update_Parameters_Action` should not blindly copy the table value when no update occurred. The exact fix depends on the Adamant framework's `Update_Parameters` semantics — if it is a no-op when nothing is staged, this issue does not manifest at runtime. **This needs verification against the framework.**
+
+**Severity:** High (if `Update_Parameters` unconditionally invokes `Update_Parameters_Action`) / Medium (if it's a no-op when nothing staged)
+
+---
+
+### Issue 3.2 — `Items_Dispatched` Variable Is Unused Beyond the Assertion (Low)
+
+**Location:** `component-limiter-implementation.adb`, `Tick_T_Recv_Sync` (line ~55–66)
+
+**Original Code:**
+```ada
+      declare
+         Max_Items_To_Dispatch : constant Natural := Natural (Self.P_Max_Sends_Per_Tick.Get_Var);
+         Items_Dispatched : Natural := 0;
+      begin
+         -- Dispatch up to our maximum items per tick off the queue:
+         if Max_Items_To_Dispatch > 0 then
+            Items_Dispatched := Self.Dispatch_N (Max_Items_To_Dispatch);
+         end if;
+
+         -- We should never dispatch more items off the queue than was
+         -- requested in the call to Dispatch_N:
+         pragma Assert (Items_Dispatched <= Max_Items_To_Dispatch);
+      end;
+```
+
+**Explanation:** `Items_Dispatched` is only used in a `pragma Assert`. In production builds with assertions disabled, the variable and the `Dispatch_N` return value are effectively unused. This is not a bug — the assertion is good defensive practice — but no data product or event is emitted indicating how many items were actually dispatched per tick. For observability in flight, consider emitting a data product with the count of items dispatched.
+
+**Severity:** Low
+
+---
+
+## 4. Unit Test Review
+
+### Issue 4.1 — No Test for Command-Then-Parameter Interaction (Medium)
+
+**Location:** `test/limiter_tests-implementation.adb`
+
+**Explanation:** `Test_Change_Rate_Command` and `Test_Change_Rate_Parameter` each test their respective mechanisms in isolation, but there is no test that:
+1. Sets a rate via command, then verifies a subsequent tick uses the commanded rate (without a parameter update reverting it).
+2. Sets a rate via command, then issues a parameter update, and verifies which value wins.
+
+Given Issue 3.1 (command/parameter desynchronization), this interaction is the most likely source of a flight anomaly and **must** be tested.
+
+**Corrected Code:** Add a test such as:
+```ada
+overriding procedure Test_Command_Parameter_Interaction (Self : in out Instance) is
+   T : Component_Tester_Package.Instance_Access renames Self.Tester;
+   The_Tick : constant Tick.T := ((0, 0), 0);
+begin
+   -- Set rate to 1 via command:
+   T.Command_T_Send (T.Commands.Sends_Per_Tick ((Value => 1)));
+   -- Enqueue 3 items:
+   T.T_Send (((0, 0), 1));
+   T.T_Send (((0, 0), 2));
+   T.T_Send (((0, 0), 3));
+   -- Tick — should send exactly 1 (commanded rate), not 3 (init) or
+   -- the parameter default:
+   T.Tick_T_Send (The_Tick);
+   Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 1);
+end Test_Command_Parameter_Interaction;
+```
+
+**Severity:** Medium
+
+---
+
+### Issue 4.2 — Test_Queue_Overflow Does Not Verify T_Send_Dropped_Count (Low)
+
+**Location:** `test/limiter_tests-implementation.adb`, `Test_Queue_Overflow` (line ~157)
+
+**Original Code:**
+```ada
+      -- OK the next command should overflow the queue.
+      T.Expect_T_Send_Dropped := True;
+      T.T_Send (((0, 0), 1));
+
+      -- Make sure event thrown:
+      Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 1);
+      Natural_Assert.Eq (T.Data_Dropped_History.Get_Count, 1);
+```
+
+**Explanation:** The tester infrastructure maintains a `T_Send_Dropped_Count` counter, but the test never asserts on it. While the event check is sufficient for verifying the component behavior, asserting `T.T_Send_Dropped_Count = 1` would verify both sides of the drop path (tester and component).
+
+**Corrected Code (add after existing assertions):**
+```ada
+      Natural_Assert.Eq (T.T_Send_Dropped_Count, 1);
+```
+
+**Severity:** Low
+
+---
+
+### Issue 4.3 — No Test for Max_Sends_Per_Tick = Unsigned_16'Last (Boundary) (Low)
+
+**Location:** `test/limiter_tests-implementation.adb`
+
+**Explanation:** No test exercises the boundary condition where `Max_Sends_Per_Tick` is set to `Unsigned_16'Last` (65535). While the conversion `Natural (Self.P_Max_Sends_Per_Tick.Get_Var)` is safe on all practical targets (Natural range includes 65535), a boundary test would confirm this and verify the component handles a very large dispatch limit gracefully (draining the queue without issues).
+
+**Severity:** Low
+
+---
+
+## 5. Summary — Top 5 Issues
+
+| # | Severity | Section | Issue |
+|---|----------|---------|-------|
+| 1 | **High** | Implementation (3.1) | Command sets protected variable but not parameter table — next tick's `Update_Parameters` may silently revert the commanded rate |
+| 2 | **Medium** | Tests (4.1) | No test for command-then-parameter interaction, leaving the desynchronization in Issue 3.1 undetected |
+| 3 | **Medium** | Model (2.1) | Parameter default (`1`) differs from typical init value (`3`) with no documented rationale |
+| 4 | **Low** | Documentation (1.1) | Data Products subsection missing from LaTeX design document |
+| 5 | **Low** | Model (1.2) | Inconsistent naming: `Max_Send_Per_Tick_Set` (singular) vs all other identifiers using plural "Sends" |

--- a/src/components/limiter/REVIEW.md
+++ b/src/components/limiter/REVIEW.md
@@ -271,3 +271,17 @@ end Test_Command_Parameter_Interaction;
 | 3 | **Medium** | Model (2.1) | Parameter default (`1`) differs from typical init value (`3`) with no documented rationale |
 | 4 | **Low** | Documentation (1.1) | Data Products subsection missing from LaTeX design document |
 | 5 | **Low** | Model (1.2) | Inconsistent naming: `Max_Send_Per_Tick_Set` (singular) vs all other identifiers using plural "Sends" |
+
+## Resolution Notes
+
+| # | Issue | Severity | Status | Commit | Notes |
+|---|-------|----------|--------|--------|-------|
+| 1 | Command/parameter desync | High | Fixed | b413cb9 | Command now syncs param table |
+| 2 | Default mismatch | Medium | Fixed | 48695ea | Aligned to 3 |
+| 3 | No interaction test | Medium | Fixed | 64646f3 | Added command-then-tick test |
+| 4 | Missing Data Products in doc | Low | Fixed | a703ce9 | Added subsection |
+| 5 | Naming inconsistency | Low | Fixed | 004b6f3 | Renamed across all files |
+| 6 | Missing overflow requirement | Low | Fixed | 571afe4 | Added |
+| 7 | Items_Dispatched observability | Low | Not Fixed | 7d03e65 | Needs model changes |
+| 8 | Drop count unasserted | Low | Fixed | 87bdcb8 | Added assertion |
+| 9 | Boundary test | Low | Fixed | 3cc5157 | Added Unsigned_16'Last test |

--- a/src/components/limiter/component-limiter-implementation.adb
+++ b/src/components/limiter/component-limiter-implementation.adb
@@ -119,7 +119,7 @@ package body Component.Limiter.Implementation is
       -- Send data product:
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Max_Packet_Sends_Per_Tick (The_Time, (Value => Self.P_Max_Sends_Per_Tick.Get_Var)));
       -- Send event:
-      Self.Event_T_Send_If_Connected (Self.Events.Max_Send_Per_Tick_Set (The_Time, Arg));
+      Self.Event_T_Send_If_Connected (Self.Events.Max_Sends_Per_Tick_Set (The_Time, Arg));
       return Success;
    end Sends_Per_Tick;
 

--- a/src/components/limiter/component-limiter-implementation.adb
+++ b/src/components/limiter/component-limiter-implementation.adb
@@ -112,8 +112,10 @@ package body Component.Limiter.Implementation is
       use Command_Execution_Status;
       The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
    begin
-      -- Set the rate:
+      -- Set the rate in both the protected variable and the parameter table
+      -- so that they stay in sync:
       Self.P_Max_Sends_Per_Tick.Set_Var (Arg.Value);
+      Self.Max_Sends_Per_Tick := (Value => Arg.Value);
       -- Send data product:
       Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Max_Packet_Sends_Per_Tick (The_Time, (Value => Self.P_Max_Sends_Per_Tick.Get_Var)));
       -- Send event:

--- a/src/components/limiter/doc/limiter.tex
+++ b/src/components/limiter/doc/limiter.tex
@@ -38,6 +38,10 @@
 
 \input{build/tex/limiter_parameters.tex}
 
+\subsection{Data Products}
+
+\input{build/tex/limiter_data_products.tex}
+
 \subsection{Events}
 
 \input{build/tex/limiter_events.tex}

--- a/src/components/limiter/limiter.events.yaml
+++ b/src/components/limiter/limiter.events.yaml
@@ -1,6 +1,6 @@
 ---
 events:
-  - name: Max_Send_Per_Tick_Set
+  - name: Max_Sends_Per_Tick_Set
     description: A new maximum sends per tick rate has been set for the limiter.
     param_type: Packed_U16.T
   - name: Data_Dropped

--- a/src/components/limiter/limiter.parameters.yaml
+++ b/src/components/limiter/limiter.parameters.yaml
@@ -4,4 +4,4 @@ parameters:
   - name: Max_Sends_Per_Tick
     description: The maximum number of packets to send out in one tick.
     type: Packed_U16.T
-    default: "(Value => 1)"
+    default: "(Value => 3)"

--- a/src/components/limiter/limiter.requirements.yaml
+++ b/src/components/limiter/limiter.requirements.yaml
@@ -5,3 +5,4 @@ requirements:
   - text: The component shall send queued data at a configurable periodic rate.
   - text: The rate at which queued data is sent shall be configurable by command.
   - text: The rate at which queued data is sent shall be configurable by parameter.
+  - text: The component shall emit an event when incoming data is dropped due to a full queue.

--- a/src/components/limiter/test/component-limiter-implementation-tester.adb
+++ b/src/components/limiter/test/component-limiter-implementation-tester.adb
@@ -24,7 +24,7 @@ package body Component.Limiter.Implementation.Tester is
       Self.Event_T_Recv_Sync_History.Init (Depth => 100);
       Self.Sys_Time_T_Return_History.Init (Depth => 100);
       -- Event histories:
-      Self.Max_Send_Per_Tick_Set_History.Init (Depth => 100);
+      Self.Max_Sends_Per_Tick_Set_History.Init (Depth => 100);
       Self.Data_Dropped_History.Init (Depth => 100);
       Self.Invalid_Command_Received_History.Init (Depth => 100);
       Self.Invalid_Parameter_Received_History.Init (Depth => 100);
@@ -42,7 +42,7 @@ package body Component.Limiter.Implementation.Tester is
       Self.Event_T_Recv_Sync_History.Destroy;
       Self.Sys_Time_T_Return_History.Destroy;
       -- Event histories:
-      Self.Max_Send_Per_Tick_Set_History.Destroy;
+      Self.Max_Sends_Per_Tick_Set_History.Destroy;
       Self.Data_Dropped_History.Destroy;
       Self.Invalid_Command_Received_History.Destroy;
       Self.Invalid_Parameter_Received_History.Destroy;
@@ -134,11 +134,11 @@ package body Component.Limiter.Implementation.Tester is
    -- Event handler primitive:
    -----------------------------------------------
    -- A new maximum sends per tick rate has been set for the limiter.
-   overriding procedure Max_Send_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T) is
+   overriding procedure Max_Sends_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T) is
    begin
       -- Push the argument onto the test history for looking at later:
-      Self.Max_Send_Per_Tick_Set_History.Push (Arg);
-   end Max_Send_Per_Tick_Set;
+      Self.Max_Sends_Per_Tick_Set_History.Push (Arg);
+   end Max_Sends_Per_Tick_Set;
 
    -- The queue for data overflowed and an incoming data was dropped.
    overriding procedure Data_Dropped (Self : in out Instance) is

--- a/src/components/limiter/test/component-limiter-implementation-tester.ads
+++ b/src/components/limiter/test/component-limiter-implementation-tester.ads
@@ -30,7 +30,7 @@ package Component.Limiter.Implementation.Tester is
    package Sys_Time_T_Return_History_Package is new Printable_History (Sys_Time.T, Sys_Time.Representation.Image);
 
    -- Event history packages:
-   package Max_Send_Per_Tick_Set_History_Package is new Printable_History (Packed_U16.T, Packed_U16.Representation.Image);
+   package Max_Sends_Per_Tick_Set_History_Package is new Printable_History (Packed_U16.T, Packed_U16.Representation.Image);
    package Data_Dropped_History_Package is new Printable_History (Natural, Natural'Image);
    package Invalid_Command_Received_History_Package is new Printable_History (Invalid_Command_Info.T, Invalid_Command_Info.Representation.Image);
    package Invalid_Parameter_Received_History_Package is new Printable_History (Invalid_Parameter_Info.T, Invalid_Parameter_Info.Representation.Image);
@@ -49,7 +49,7 @@ package Component.Limiter.Implementation.Tester is
       Event_T_Recv_Sync_History : Event_T_Recv_Sync_History_Package.Instance;
       Sys_Time_T_Return_History : Sys_Time_T_Return_History_Package.Instance;
       -- Event histories:
-      Max_Send_Per_Tick_Set_History : Max_Send_Per_Tick_Set_History_Package.Instance;
+      Max_Sends_Per_Tick_Set_History : Max_Sends_Per_Tick_Set_History_Package.Instance;
       Data_Dropped_History : Data_Dropped_History_Package.Instance;
       Invalid_Command_Received_History : Invalid_Command_Received_History_Package.Instance;
       Invalid_Parameter_Received_History : Invalid_Parameter_Received_History_Package.Instance;
@@ -96,7 +96,7 @@ package Component.Limiter.Implementation.Tester is
    -- Event handler primitive:
    -----------------------------------------------
    -- A new maximum sends per tick rate has been set for the limiter.
-   overriding procedure Max_Send_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T);
+   overriding procedure Max_Sends_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T);
    -- The queue for data overflowed and an incoming data was dropped.
    overriding procedure Data_Dropped (Self : in out Instance);
    -- A command was received with invalid parameters.

--- a/src/components/limiter/test/limiter.tests.yaml
+++ b/src/components/limiter/test/limiter.tests.yaml
@@ -15,3 +15,5 @@ tests:
     description: This unit test exercises that an invalid parameter throws the appropriate event.
   - name: Test_Command_Parameter_Interaction
     description: This unit test verifies that a rate set by command persists across ticks and is not silently reverted by the parameter update mechanism.
+  - name: Test_Max_Sends_Boundary
+    description: This unit test exercises the boundary condition where Max_Sends_Per_Tick is set to Unsigned_16'Last (65535).

--- a/src/components/limiter/test/limiter.tests.yaml
+++ b/src/components/limiter/test/limiter.tests.yaml
@@ -13,3 +13,5 @@ tests:
     description: This unit test exercises that an invalid command throws the appropriate event.
   - name: Test_Invalid_Parameter
     description: This unit test exercises that an invalid parameter throws the appropriate event.
+  - name: Test_Command_Parameter_Interaction
+    description: This unit test verifies that a rate set by command persists across ticks and is not silently reverted by the parameter update mechanism.

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -385,4 +385,27 @@ package body Limiter_Tests.Implementation is
       Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 3);
    end Test_Command_Parameter_Interaction;
 
+   overriding procedure Test_Max_Sends_Boundary (Self : in out Instance) is
+      T : Component_Tester_Package.Instance_Access renames Self.Tester;
+      The_Tick : constant Tick.T := ((0, 0), 0);
+   begin
+      -- Set rate to Unsigned_16'Last via command:
+      T.Command_T_Send (T.Commands.Sends_Per_Tick ((Value => Interfaces.Unsigned_16'Last)));
+      Natural_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get_Count, 1);
+      Command_Response_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get (1), (Source_Id => 0, Registration_Id => 0, Command_Id => T.Commands.Get_Sends_Per_Tick_Id, Status => Success));
+
+      -- Enqueue 4 items (queue max) and tick — all should drain since
+      -- 65535 > 4:
+      T.T_Send (((0, 0), 1));
+      T.T_Send (((0, 0), 2));
+      T.T_Send (((0, 0), 3));
+      T.T_Send (((0, 0), 4));
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 4);
+
+      -- Next tick should produce nothing:
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 4);
+   end Test_Max_Sends_Boundary;
+
 end Limiter_Tests.Implementation;

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -350,4 +350,37 @@ package body Limiter_Tests.Implementation is
       Invalid_Parameter_Info_Assert.Eq (T.Invalid_Parameter_Received_History.Get (2), (Id => 1_001, Errant_Field_Number => Interfaces.Unsigned_32'Last - 1, Errant_Field => [0, 0, 0, 0, 0, 0, 16#03#, 16#E9#]));
    end Test_Invalid_Parameter;
 
+   overriding procedure Test_Command_Parameter_Interaction (Self : in out Instance) is
+      T : Component_Tester_Package.Instance_Access renames Self.Tester;
+      The_Tick : constant Tick.T := ((0, 0), 0);
+   begin
+      -- Set rate to 1 via command:
+      T.Command_T_Send (T.Commands.Sends_Per_Tick ((Value => 1)));
+      Natural_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get_Count, 1);
+      Command_Response_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get (1), (Source_Id => 0, Registration_Id => 0, Command_Id => T.Commands.Get_Sends_Per_Tick_Id, Status => Success));
+
+      -- Enqueue 3 items:
+      T.T_Send (((0, 0), 1));
+      T.T_Send (((0, 0), 2));
+      T.T_Send (((0, 0), 3));
+
+      -- Tick — should send exactly 1 (commanded rate), not 3 (init) or
+      -- the parameter default. The tick calls Update_Parameters internally,
+      -- so this also verifies the command value is not reverted:
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 1);
+
+      -- Second tick should send 1 more, confirming the rate persists:
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 2);
+
+      -- Third tick drains the last item:
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 3);
+
+      -- Fourth tick — queue empty, no more sends:
+      T.Tick_T_Send (The_Tick);
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 3);
+   end Test_Command_Parameter_Interaction;
+
 end Limiter_Tests.Implementation;

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -299,6 +299,8 @@ package body Limiter_Tests.Implementation is
       -- Make sure event thrown:
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 1);
       Natural_Assert.Eq (T.Data_Dropped_History.Get_Count, 1);
+      -- Verify the tester's drop counter as well:
+      Natural_Assert.Eq (T.T_Send_Dropped_Count, 1);
    end Test_Queue_Overflow;
 
    overriding procedure Test_Invalid_Command (Self : in out Instance) is

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -144,8 +144,8 @@ package body Limiter_Tests.Implementation is
 
       -- Check event.
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 1);
-      Natural_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get_Count, 1);
-      Packed_U16_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get (1), (Value => 0));
+      Natural_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get_Count, 1);
+      Packed_U16_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get (1), (Value => 0));
 
       -- Check data product:
       Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 1);
@@ -172,8 +172,8 @@ package body Limiter_Tests.Implementation is
 
       -- Check event.
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 2);
-      Natural_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get_Count, 2);
-      Packed_U16_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get (2), (Value => 2));
+      Natural_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get_Count, 2);
+      Packed_U16_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get (2), (Value => 2));
 
       -- Check data product:
       Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 2);
@@ -191,8 +191,8 @@ package body Limiter_Tests.Implementation is
 
       -- Check event.
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 3);
-      Natural_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get_Count, 3);
-      Packed_U16_Assert.Eq (T.Max_Send_Per_Tick_Set_History.Get (3), (Value => 1));
+      Natural_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get_Count, 3);
+      Packed_U16_Assert.Eq (T.Max_Sends_Per_Tick_Set_History.Get (3), (Value => 1));
 
       -- Check data product:
       Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 3);

--- a/src/components/limiter/test/limiter_tests-implementation.ads
+++ b/src/components/limiter/test/limiter_tests-implementation.ads
@@ -27,6 +27,8 @@ private
    overriding procedure Test_Invalid_Command (Self : in out Instance);
    -- This unit test exercises that an invalid parameter throws the appropriate event.
    overriding procedure Test_Invalid_Parameter (Self : in out Instance);
+   -- This unit test verifies that a rate set by command persists across ticks and is not silently reverted by the parameter update mechanism.
+   overriding procedure Test_Command_Parameter_Interaction (Self : in out Instance);
 
    -- Instantiate generic component package:
    package Component_Package is new Component.Limiter (T => Tick.T, Serialized_Length => Tick.Serialized_Length);

--- a/src/components/limiter/test/limiter_tests-implementation.ads
+++ b/src/components/limiter/test/limiter_tests-implementation.ads
@@ -29,6 +29,8 @@ private
    overriding procedure Test_Invalid_Parameter (Self : in out Instance);
    -- This unit test verifies that a rate set by command persists across ticks and is not silently reverted by the parameter update mechanism.
    overriding procedure Test_Command_Parameter_Interaction (Self : in out Instance);
+   -- This unit test exercises the boundary condition where Max_Sends_Per_Tick is set to Unsigned_16'Last (65535).
+   overriding procedure Test_Max_Sends_Boundary (Self : in out Instance);
 
    -- Instantiate generic component package:
    package Component_Package is new Component.Limiter (T => Tick.T, Serialized_Length => Tick.Serialized_Length);

--- a/src/components/limiter/test_variable/component-limiter-implementation-tester.adb
+++ b/src/components/limiter/test_variable/component-limiter-implementation-tester.adb
@@ -24,7 +24,7 @@ package body Component.Limiter.Implementation.Tester is
       Self.Event_T_Recv_Sync_History.Init (Depth => 100);
       Self.Sys_Time_T_Return_History.Init (Depth => 100);
       -- Event histories:
-      Self.Max_Send_Per_Tick_Set_History.Init (Depth => 100);
+      Self.Max_Sends_Per_Tick_Set_History.Init (Depth => 100);
       Self.Data_Dropped_History.Init (Depth => 100);
       Self.Invalid_Command_Received_History.Init (Depth => 100);
       Self.Invalid_Parameter_Received_History.Init (Depth => 100);
@@ -42,7 +42,7 @@ package body Component.Limiter.Implementation.Tester is
       Self.Event_T_Recv_Sync_History.Destroy;
       Self.Sys_Time_T_Return_History.Destroy;
       -- Event histories:
-      Self.Max_Send_Per_Tick_Set_History.Destroy;
+      Self.Max_Sends_Per_Tick_Set_History.Destroy;
       Self.Data_Dropped_History.Destroy;
       Self.Invalid_Command_Received_History.Destroy;
       Self.Invalid_Parameter_Received_History.Destroy;
@@ -134,11 +134,11 @@ package body Component.Limiter.Implementation.Tester is
    -- Event handler primitive:
    -----------------------------------------------
    -- A new maximum sends per tick rate has been set for the limiter.
-   overriding procedure Max_Send_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T) is
+   overriding procedure Max_Sends_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T) is
    begin
       -- Push the argument onto the test history for looking at later:
-      Self.Max_Send_Per_Tick_Set_History.Push (Arg);
-   end Max_Send_Per_Tick_Set;
+      Self.Max_Sends_Per_Tick_Set_History.Push (Arg);
+   end Max_Sends_Per_Tick_Set;
 
    -- The queue for data overflowed and an incoming data was dropped.
    overriding procedure Data_Dropped (Self : in out Instance) is

--- a/src/components/limiter/test_variable/component-limiter-implementation-tester.ads
+++ b/src/components/limiter/test_variable/component-limiter-implementation-tester.ads
@@ -30,7 +30,7 @@ package Component.Limiter.Implementation.Tester is
    package Sys_Time_T_Return_History_Package is new Printable_History (Sys_Time.T, Sys_Time.Representation.Image);
 
    -- Event history packages:
-   package Max_Send_Per_Tick_Set_History_Package is new Printable_History (Packed_U16.T, Packed_U16.Representation.Image);
+   package Max_Sends_Per_Tick_Set_History_Package is new Printable_History (Packed_U16.T, Packed_U16.Representation.Image);
    package Data_Dropped_History_Package is new Printable_History (Natural, Natural'Image);
    package Invalid_Command_Received_History_Package is new Printable_History (Invalid_Command_Info.T, Invalid_Command_Info.Representation.Image);
    package Invalid_Parameter_Received_History_Package is new Printable_History (Invalid_Parameter_Info.T, Invalid_Parameter_Info.Representation.Image);
@@ -49,7 +49,7 @@ package Component.Limiter.Implementation.Tester is
       Event_T_Recv_Sync_History : Event_T_Recv_Sync_History_Package.Instance;
       Sys_Time_T_Return_History : Sys_Time_T_Return_History_Package.Instance;
       -- Event histories:
-      Max_Send_Per_Tick_Set_History : Max_Send_Per_Tick_Set_History_Package.Instance;
+      Max_Sends_Per_Tick_Set_History : Max_Sends_Per_Tick_Set_History_Package.Instance;
       Data_Dropped_History : Data_Dropped_History_Package.Instance;
       Invalid_Command_Received_History : Invalid_Command_Received_History_Package.Instance;
       Invalid_Parameter_Received_History : Invalid_Parameter_Received_History_Package.Instance;
@@ -96,7 +96,7 @@ package Component.Limiter.Implementation.Tester is
    -- Event handler primitive:
    -----------------------------------------------
    -- A new maximum sends per tick rate has been set for the limiter.
-   overriding procedure Max_Send_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T);
+   overriding procedure Max_Sends_Per_Tick_Set (Self : in out Instance; Arg : in Packed_U16.T);
    -- The queue for data overflowed and an incoming data was dropped.
    overriding procedure Data_Dropped (Self : in out Instance);
    -- A command was received with invalid parameters.


### PR DESCRIPTION
1 HIGH (command/parameter desync — commanded rate silently reverted on next tick). See `REVIEW.md`.