### PR TITLE
Code review: src/components/memory_copier

### DIFF
--- a/src/components/memory_copier/REVIEW.md
+++ b/src/components/memory_copier/REVIEW.md
@@ -262,3 +262,19 @@ Task_Response : Memory_Enums.Memory_Copy_Status.E := Memory_Enums.Memory_Copy_St
 | 3 | IMPL-03 | **High** | Zero-length copy produces underflow in `End_Index` computation (`Address + 0 - 1`), not rejected anywhere. |
 | 4 | TEST-01 | **High** | Second length-mismatch assertion uses a coincidentally correct expected value; fragile to scratch size changes. |
 | 5 | MOD-01 | **Medium** | `Memory_Region_Copy_T_Send_Dropped` is silently null — a dropped copy request causes silent timeout with no diagnostic, and a dropped release leaks scratch memory. |
+
+## Resolution Notes
+
+| # | Issue | Severity | Status | Commit | Notes |
+|---|-------|----------|--------|--------|-------|
+| 1 | pragma Assert in prod | Critical | Fixed | ce34a05 | Runtime check + graceful failure |
+| 2 | Address+Length overflow | High | Fixed | d40cdad | Overflow guard |
+| 3 | Zero-length underflow | High | Fixed | 9fb213b | Early rejection |
+| 4 | Fragile test assertion | High | Fixed | 4db8d56 | Explicit expression |
+| 5 | Null dropped handlers | Medium | Fixed | 310958b | Event logging |
+| 6 | Spurious response acceptance | Medium | Fixed | 86aa8e8 | Is_Waiting guard |
+| 7 | Zero-length test missing | Medium | Not Fixed | 582e207 | Needs codegen |
+| 8 | Sleep-based sync | Medium | Not Fixed | fc27bc6 | Needs infra redesign |
+| 9 | Misleading comments | Low | Fixed | a6a0d1e | Corrected |
+| 10 | Insufficient requirements | Low | Fixed | 7bd249d | 5 added |
+| 11 | Unsynchronized globals | Low | Fixed | 9a05947 | Protected object |

--- a/src/components/memory_copier/REVIEW.md
+++ b/src/components/memory_copier/REVIEW.md
@@ -1,0 +1,264 @@
+# Memory Copier Component — Code Review
+
+**Branch:** `review/components-memory-copier`
+**Date:** 2026-02-28
+**Reviewer:** Automated (Claude)
+
+---
+
+## 1. Documentation Review
+
+### DOC-01 — Stale/misleading comments in test code (Low)
+
+**File:** `test/memory_copier_tests-implementation.adb`, multiple test procedures
+
+**Original code (appears in Test_Copy_Failure, Test_Copy_Timeout, Test_Memory_Unavailable, Test_Length_Mismatch):**
+```ada
+-- Send command to copy region 1 byte too large:
+```
+
+**Explanation:** This comment is copy-pasted into tests where it does not apply. In `Test_Copy_Failure` the region is 5 bytes (fits fine); in `Test_Copy_Timeout` the full scratch length is used (fits exactly); in `Test_Memory_Unavailable` the full scratch length is used. The comment only makes sense in `Test_Length_Mismatch`. Misleading comments in safety-critical test code erode trust in the test intent.
+
+**Corrected code:**
+- `Test_Copy_Failure`: `-- Send command to copy region (will return failure status):`
+- `Test_Copy_Timeout`: `-- Send command to copy region (will time out):`
+- `Test_Memory_Unavailable`: `-- Send command to copy region (memory will be unavailable):`
+
+**Severity:** Low
+
+### DOC-02 — Single requirement is too coarse (Low)
+
+**File:** `memory_copier.requirements.yaml`
+
+**Original code:**
+```yaml
+requirements:
+  - text: The component shall copy a memory region from one memory store to another on command.
+```
+
+**Explanation:** A single requirement covers only the happy path. There are no requirements for timeout behavior, error reporting on failure, memory-unavailable handling, or length-mismatch detection — all of which are implemented and tested. This makes requirements traceability incomplete. Each distinct behavior (timeout, copy failure, memory unavailable, length mismatch, command validation) should have a corresponding requirement.
+
+**Corrected code:**
+```yaml
+requirements:
+  - text: The component shall copy a memory region from one memory store to another on command.
+  - text: The component shall report a timeout error if the copy operation does not complete within the configured tick limit.
+  - text: The component shall report an error if the downstream component returns a copy failure status.
+  - text: The component shall report an error if the requested scratch memory region is unavailable.
+  - text: The component shall report an error if the scratch memory region is smaller than the requested source region.
+  - text: The component shall reject commands with invalid parameters and report an event.
+```
+
+**Severity:** Low
+
+---
+
+## 2. Model Review
+
+### MOD-01 — `Memory_Region_Copy_T_Send_Dropped` and `Ided_Memory_Region_Release_Dropped` are silently ignored (Medium)
+
+**File:** `component-memory_copier-implementation.ads`, lines near the end of private section
+
+**Original code:**
+```ada
+overriding procedure Memory_Region_Copy_T_Send_Dropped (Self : in out Instance; Arg : in Memory_Region_Copy.T) is null;
+overriding procedure Ided_Memory_Region_Release_Dropped (Self : in out Instance; Arg : in Ided_Memory_Region.T) is null;
+```
+
+**Explanation:** If the memory region copy send connector drops a message, the component will wait until timeout with no indication of *why* — the copy request was never delivered. Similarly, if the release is dropped, the scratch memory region is leaked permanently. In a flight system these are serious failure modes. At minimum, an event should be emitted, or the component should track this condition and fail the command immediately. The `Command_Response_T_Send_Dropped` and `Event_T_Send_Dropped` being null are more defensible (less the component can do), but these two have actionable consequences.
+
+**Corrected code (example for copy send dropped):**
+```ada
+overriding procedure Memory_Region_Copy_T_Send_Dropped (Self : in out Instance; Arg : in Memory_Region_Copy.T) is
+begin
+   -- At minimum, log that the copy request was never delivered.
+   -- The component will eventually time out, but this provides root cause.
+   Self.Event_T_Send_If_Connected (Self.Events.Copy_Failure (Self.Sys_Time_T_Get,
+      (Region => Arg.Source_Region, Status => Memory_Enums.Memory_Copy_Status.Failure)));
+end Memory_Region_Copy_T_Send_Dropped;
+```
+
+**Severity:** Medium
+
+---
+
+## 3. Component Implementation Review
+
+### IMPL-01 — `pragma Assert` used for runtime validation in flight code (Critical)
+
+**File:** `component-memory_copier-implementation.adb`, in `Copy_Memory_Region`
+
+**Original code:**
+```ada
+pragma Assert (Ided_Region.Region.Length = Arg.Source_Length, "We assume it is this length after the function call.");
+```
+
+**Explanation:** `pragma Assert` is typically disabled in production builds (`-gnata` is not a flight build flag). This assertion documents a critical assumption — that the returned region length equals the requested source length — but does nothing in production. If the assumption is violated, the component would send a region with an incorrect length to the downstream copier, potentially corrupting memory. This should be a proper runtime check that fails the command gracefully rather than a suppressible assertion.
+
+Furthermore, the assumption is **incorrect**: `Request_Memory_Region` returns a *sliced* region where `Returned_Physical_Region.Region.Length` equals `Virtual_Region.Length` (i.e., `Arg.Source_Length`), but this is only true because `Byte_Array_Pointer.Slice` constructs it that way. The check is tautological given the slice logic, and if it ever failed it would indicate memory corruption. A proper defensive check is still warranted.
+
+**Corrected code:**
+```ada
+-- Verify the returned region matches the expected length. If not, fail gracefully.
+if Ided_Region.Region.Length /= Arg.Source_Length then
+   Self.Ided_Memory_Region_Release (Ided_Region);
+   return Failure;
+end if;
+```
+
+**Severity:** Critical
+
+### IMPL-02 — Integer overflow in `Request_Memory_Region` computing `Min_Length` (High)
+
+**File:** `component-memory_copier-implementation.adb`, in `Request_Memory_Region`
+
+**Original code:**
+```ada
+Min_Length : constant Natural := Virtual_Region.Address + Virtual_Region.Length;
+```
+
+**Explanation:** `Virtual_Region.Address` and `Virtual_Region.Length` are both `Natural` values that come (ultimately) from a ground command. If an attacker or operator error sends `Address = Natural'Last` and `Length = 1`, the addition overflows. In Ada with checks enabled this raises `Constraint_Error`, which in a flight system would crash the task (and potentially the partition). The component should validate inputs before performing arithmetic, or use a safe addition pattern.
+
+**Corrected code:**
+```ada
+-- Guard against overflow: Natural'Last is the maximum value.
+if Virtual_Region.Address > Natural'Last - Virtual_Region.Length then
+   -- The virtual region exceeds addressable range — fail gracefully.
+   Self.Event_T_Send_If_Connected (Self.Events.Memory_Region_Length_Mismatch (Self.Sys_Time_T_Get,
+      (Region => (Address => System.Null_Address, Length => 0),
+       Expected_Length => 0)));
+   return False;
+end if;
+Min_Length : constant Natural := Virtual_Region.Address + Virtual_Region.Length;
+```
+
+**Severity:** High
+
+### IMPL-03 — `Slice` call with `End_Index = -1` when `Virtual_Region.Length = 0` (High)
+
+**File:** `component-memory_copier-implementation.adb`, in `Request_Memory_Region`
+
+**Original code:**
+```ada
+Ptr_Slice : constant Byte_Array_Pointer.Instance := Slice (
+   Ptr,
+   Start_Index => Virtual_Region.Address,
+   End_Index => Virtual_Region.Address + Virtual_Region.Length - 1
+);
+```
+
+**Explanation:** If `Virtual_Region.Length = 0` (a zero-length copy command, which is not rejected anywhere), then `End_Index` underflows: `Virtual_Region.Address + 0 - 1`. If `Address = 0`, this computes `Natural'Last` (wraparound) or raises `Constraint_Error` depending on the type. A zero-length copy should either be rejected at command validation time, or handled explicitly here.
+
+**Corrected code (option A — reject zero-length early in `Copy_Memory_Region`):**
+```ada
+if Arg.Source_Length = 0 then
+   Self.Event_T_Send_If_Connected (Self.Events.Invalid_Command_Received (Self.Sys_Time_T_Get,
+      (Id => <command_id>, Errant_Field_Number => 1, Errant_Field => [others => 0])));
+   return Failure;
+end if;
+```
+
+**Severity:** High
+
+### IMPL-04 — Race condition documented but not mitigated (Medium)
+
+**File:** `component-memory_copier-implementation.adb`, in `Memory_Region_Release_T_Recv_Sync`, comment block
+
+**Original code:**
+```ada
+-- Note, there is a possible race condition here. Think, we could set the response
+-- within the component, and then release it to allow reading of this data. Before
+-- the component reads the data, however, we may receive another response, overwriting
+-- the data ...
+```
+
+**Explanation:** The race condition is acknowledged and hand-waved as "should never occur if the assembly is designed correctly." In safety-critical code, "should never" is not sufficient mitigation. A sequence counter or flag-check in `Memory_Region_Release_T_Recv_Sync` that rejects unexpected/duplicate responses (e.g., when the component is not in the waiting state) would be a low-cost defensive measure that transforms "should never" into "cannot."
+
+**Corrected code (sketch):**
+```ada
+overriding procedure Memory_Region_Release_T_Recv_Sync (Self : in out Instance; Arg : in Memory_Region_Release.T) is
+begin
+   if not Self.Sync_Object.Is_Waiting then
+      -- Spurious response — ignore or log
+      return;
+   end if;
+   Self.Response.Set_Var (Arg);
+   Self.Sync_Object.Release;
+end Memory_Region_Release_T_Recv_Sync;
+```
+
+**Severity:** Medium
+
+---
+
+## 4. Unit Test Review
+
+### TEST-01 — Second length-mismatch assertion checks wrong expected length (High)
+
+**File:** `test/memory_copier_tests-implementation.adb`, in `Test_Length_Mismatch`, second sub-test
+
+**Original code:**
+```ada
+-- Send command: Source_Address => 5, Source_Length => T.Scratch'Length - 4
+-- ...
+Invalid_Memory_Region_Length_Assert.Eq (T.Memory_Region_Length_Mismatch_History.Get (2),
+   (Region => (T.Scratch'Address, T.Scratch'Length), Expected_Length => T.Scratch'Length + 1));
+```
+
+**Explanation:** The second command sends `Source_Address => 5, Source_Length => T.Scratch'Length - 4`. The implementation computes `Min_Length = Address + Length = 5 + (T.Scratch'Length - 4) = T.Scratch'Length + 1`. So the expected value `T.Scratch'Length + 1` happens to be numerically correct *by coincidence* — the scratch length is 100, Address=5, Length=96, Min=101=100+1. The assertion technically passes, but the test appears to be testing address-offset behavior while reusing the same expected value as the first sub-case. This is fragile and misleading. If scratch size changes, both sub-tests would need updating and the coincidence may not hold. The expected length should be expressed as `5 + (T.Scratch'Length - 4)` to clearly document intent.
+
+**Corrected code:**
+```ada
+Invalid_Memory_Region_Length_Assert.Eq (T.Memory_Region_Length_Mismatch_History.Get (2),
+   (Region => (T.Scratch'Address, T.Scratch'Length), Expected_Length => 5 + (T.Scratch'Length - 4)));
+```
+
+**Severity:** High (test correctness — masks future regressions if scratch size changes)
+
+### TEST-02 — No test for zero-length copy command (Medium)
+
+**File:** `test/memory_copier_tests-implementation.adb` (missing test)
+
+**Explanation:** No test sends `Source_Length => 0`. As identified in IMPL-03, this is a boundary condition that can cause a runtime exception. The test suite should include a zero-length copy test to verify the component handles this edge case.
+
+**Severity:** Medium
+
+### TEST-03 — Timing-dependent tests use `Sleep` with hardcoded durations (Medium)
+
+**File:** `test/memory_copier_tests-implementation.adb`, throughout
+
+**Original code:**
+```ada
+Sleep (4);
+```
+
+**Explanation:** Multiple tests depend on `Sleep(4)` (4 ms) being sufficient for the simulator task to process the response and for the component to observe it. On a loaded system or with different scheduling, these tests could become flaky. While this is common in testing concurrent code, it is worth noting for CI reliability. The use of a synchronization primitive rather than timed sleeps would be more robust.
+
+**Severity:** Medium
+
+### TEST-04 — Global mutable state for task control is not thread-safe (Low)
+
+**File:** `test/memory_copier_tests-implementation.adb`, top of body
+
+**Original code:**
+```ada
+Task_Send_Response : Boolean := False;
+Task_Send_Timeout : Boolean := False;
+Task_Response : Memory_Enums.Memory_Copy_Status.E := Memory_Enums.Memory_Copy_Status.Success;
+```
+
+**Explanation:** The comment acknowledges "There is no thread safety here... but this is testing code." While pragmatically acceptable, these variables are read/written by both the test task and the simulator task without synchronization. On architectures with weak memory ordering this could cause subtle test failures. A protected object would be trivial to add.
+
+**Severity:** Low
+
+---
+
+## 5. Summary — Top 5 Issues
+
+| # | ID | Severity | Summary |
+|---|------|----------|---------|
+| 1 | IMPL-01 | **Critical** | `pragma Assert` guards a critical length assumption but is disabled in production builds. Should be a proper runtime check with graceful failure. |
+| 2 | IMPL-02 | **High** | `Address + Length` can overflow `Natural` on adversarial command input, causing `Constraint_Error` in flight. |
+| 3 | IMPL-03 | **High** | Zero-length copy produces underflow in `End_Index` computation (`Address + 0 - 1`), not rejected anywhere. |
+| 4 | TEST-01 | **High** | Second length-mismatch assertion uses a coincidentally correct expected value; fragile to scratch size changes. |
+| 5 | MOD-01 | **Medium** | `Memory_Region_Copy_T_Send_Dropped` is silently null — a dropped copy request causes silent timeout with no diagnostic, and a dropped release leaks scratch memory. |

--- a/src/components/memory_copier/component-memory_copier-implementation.adb
+++ b/src/components/memory_copier/component-memory_copier-implementation.adb
@@ -202,7 +202,11 @@ package body Component.Memory_Copier.Implementation is
       if not Self.Request_Memory_Region (Virtual_Region => (Address => Arg.Source_Address, Length => Arg.Source_Length), Returned_Physical_Region => Ided_Region) then
          return Failure;
       end if;
-      pragma Assert (Ided_Region.Region.Length = Arg.Source_Length, "We assume it is this length after the function call.");
+      -- Verify the returned region matches the expected length. If not, fail gracefully.
+      if Ided_Region.Region.Length /= Arg.Source_Length then
+         Self.Ided_Memory_Region_Release (Ided_Region);
+         return Failure;
+      end if;
 
       -- Send Region to the destination
       if not Self.Copy_To_Destination ((Source_Region => Ided_Region.Region, Destination_Address => Arg.Destination_Address)) then

--- a/src/components/memory_copier/component-memory_copier-implementation.adb
+++ b/src/components/memory_copier/component-memory_copier-implementation.adb
@@ -50,26 +50,19 @@ package body Component.Memory_Copier.Implementation is
    -- The memory region is returned synchronously on this connector. The component waits internally for this response, or times out if the response is not received in time.
    overriding procedure Memory_Region_Release_T_Recv_Sync (Self : in out Instance; Arg : in Memory_Region_Release.T) is
    begin
-      -- First set the protected response with the response from the component.
-      -- In this function we simply store whatever we get. The error handling based on the
-      -- contents of this response are done by this component's task (executing the command).
+      -- Guard against spurious or duplicate responses: only accept when we are actually waiting.
+      if not Self.Sync_Object.Is_Waiting then
+         -- Spurious response received while not waiting — ignore it.
+         return;
+      end if;
+
+      -- Set the protected response with the response from the component.
+      -- The error handling based on the contents of this response are done by this
+      -- component's task (executing the command).
       Self.Response.Set_Var (Arg);
 
-      -- Ok we have stored the response for the component to look at later. Now we signal
-      -- to the component that a response has been received and it can read it.
+      -- Signal to the component that a response has been received and it can read it.
       Self.Sync_Object.Release;
-
-      -- Note, there is a possible race condition here. Think, we could set the response
-      -- within the component, and then release it to allow reading of this data. Before
-      -- the component reads the data, however, we may receive another response, overwriting
-      -- the data the component receives before it can read the old data. This sounds serious,
-      -- but this behavior should never occur, since the downstream components should not ever
-      -- return a response to this component unprovoked.
-      --
-      -- Note, the protected buffer and the sync object are both protected objects, so there
-      -- is no risk of data corruption (which would be a serious problem), there is just risk of
-      -- out of order synchronization, which should not occur if the assembly is designed
-      -- correctly, as described above.
    end Memory_Region_Release_T_Recv_Sync;
 
    -- This procedure is called when a Command_T_Recv_Async message is dropped due to a full queue.

--- a/src/components/memory_copier/component-memory_copier-implementation.adb
+++ b/src/components/memory_copier/component-memory_copier-implementation.adb
@@ -87,10 +87,19 @@ package body Component.Memory_Copier.Implementation is
       Request : constant Memory_Region_Request.T := Self.Memory_Region_Request_T_Get;
       -- Calculate the minimum length that the requested region must have in order for
       -- the virtual memory region to be valid.
-      Min_Length : constant Natural := Virtual_Region.Address + Virtual_Region.Length;
+      -- Guard against overflow: if Address + Length would exceed Natural'Last, fail gracefully.
+      Min_Length : Natural;
    begin
       -- Initialize out parameter to null in case we fail to find memory region
       Returned_Physical_Region := (Id => 0, Region => (Address => System.Null_Address, Length => 0));
+
+      -- Guard against overflow in Address + Length computation:
+      if Virtual_Region.Address > Natural'Last - Virtual_Region.Length then
+         Self.Event_T_Send_If_Connected (Self.Events.Memory_Region_Length_Mismatch (Self.Sys_Time_T_Get,
+            (Region => (Address => System.Null_Address, Length => 0), Expected_Length => 0)));
+         return False;
+      end if;
+      Min_Length := Virtual_Region.Address + Virtual_Region.Length;
 
       -- Check the request memory status:
       case Request.Status is

--- a/src/components/memory_copier/component-memory_copier-implementation.adb
+++ b/src/components/memory_copier/component-memory_copier-implementation.adb
@@ -79,6 +79,22 @@ package body Component.Memory_Copier.Implementation is
       Self.Event_T_Send_If_Connected (Self.Events.Command_Dropped (Self.Sys_Time_T_Get, Arg.Header));
    end Command_T_Recv_Async_Dropped;
 
+   -- This procedure is called when a Memory_Region_Copy_T_Send message is dropped due to a full queue.
+   -- Log the failure so the eventual timeout has root-cause context.
+   overriding procedure Memory_Region_Copy_T_Send_Dropped (Self : in out Instance; Arg : in Memory_Region_Copy.T) is
+   begin
+      Self.Event_T_Send_If_Connected (Self.Events.Copy_Failure (Self.Sys_Time_T_Get,
+         (Region => Arg.Source_Region, Status => Memory_Enums.Memory_Copy_Status.Failure)));
+   end Memory_Region_Copy_T_Send_Dropped;
+
+   -- This procedure is called when a Memory_Region_Release message is dropped due to a full queue.
+   -- Log the leak so operators know scratch memory was not released.
+   overriding procedure Ided_Memory_Region_Release_Dropped (Self : in out Instance; Arg : in Ided_Memory_Region.T) is
+      Ignore : Ided_Memory_Region.T renames Arg;
+   begin
+      Self.Event_T_Send_If_Connected (Self.Events.Memory_Region_Unavailable (Self.Sys_Time_T_Get));
+   end Ided_Memory_Region_Release_Dropped;
+
    -- Helper which requests source memory region and does some basic error handling on it. The returned
    -- region from this function will have the address and length specified by the Virtual_Region parameter.
    function Request_Memory_Region (Self : in out Instance; Virtual_Region : in Virtual_Memory_Region.T; Returned_Physical_Region : out Ided_Memory_Region.T) return Boolean is

--- a/src/components/memory_copier/component-memory_copier-implementation.adb
+++ b/src/components/memory_copier/component-memory_copier-implementation.adb
@@ -203,6 +203,13 @@ package body Component.Memory_Copier.Implementation is
       use Command_Execution_Status;
       Ided_Region : Ided_Memory_Region.T;
    begin
+      -- Reject zero-length copy commands to prevent underflow in End_Index computation.
+      if Arg.Source_Length = 0 then
+         Self.Event_T_Send_If_Connected (Self.Events.Invalid_Command_Received (Self.Sys_Time_T_Get,
+            (Id => 0, Errant_Field_Number => 1, Errant_Field => [others => 0])));
+         return Failure;
+      end if;
+
       -- Send informational event:
       Self.Event_T_Send_If_Connected (Self.Events.Starting_Copy (Self.Sys_Time_T_Get, Arg));
 

--- a/src/components/memory_copier/component-memory_copier-implementation.ads
+++ b/src/components/memory_copier/component-memory_copier-implementation.ads
@@ -69,9 +69,9 @@ private
    -- This procedure is called when a Command_Response_T_Send message is dropped due to a full queue.
    overriding procedure Command_Response_T_Send_Dropped (Self : in out Instance; Arg : in Command_Response.T) is null;
    -- This procedure is called when a Memory_Region_Copy_T_Send message is dropped due to a full queue.
-   overriding procedure Memory_Region_Copy_T_Send_Dropped (Self : in out Instance; Arg : in Memory_Region_Copy.T) is null;
+   overriding procedure Memory_Region_Copy_T_Send_Dropped (Self : in out Instance; Arg : in Memory_Region_Copy.T);
    -- This procedure is called when a Memory_Region_Release message is dropped due to a full queue.
-   overriding procedure Ided_Memory_Region_Release_Dropped (Self : in out Instance; Arg : in Ided_Memory_Region.T) is null;
+   overriding procedure Ided_Memory_Region_Release_Dropped (Self : in out Instance; Arg : in Ided_Memory_Region.T);
    -- This procedure is called when a Event_T_Send message is dropped due to a full queue.
    overriding procedure Event_T_Send_Dropped (Self : in out Instance; Arg : in Event.T) is null;
 

--- a/src/components/memory_copier/memory_copier.requirements.yaml
+++ b/src/components/memory_copier/memory_copier.requirements.yaml
@@ -2,3 +2,8 @@
 description: The requirements for the Memory Copier component are specified below.
 requirements:
   - text: The component shall copy a memory region from one memory store to another on command.
+  - text: The component shall report a timeout error if the copy operation does not complete within the configured tick limit.
+  - text: The component shall report an error if the downstream component returns a copy failure status.
+  - text: The component shall report an error if the requested scratch memory region is unavailable.
+  - text: The component shall report an error if the scratch memory region is smaller than the requested source region.
+  - text: The component shall reject commands with invalid parameters and report an event.

--- a/src/components/memory_copier/test/memory_copier_tests-implementation.adb
+++ b/src/components/memory_copier/test/memory_copier_tests-implementation.adb
@@ -327,7 +327,7 @@ package body Memory_Copier_Tests.Implementation is
       Natural_Assert.Eq (T.Starting_Copy_History.Get_Count, 2);
       Virtual_Memory_Region_Copy_Assert.Eq (T.Starting_Copy_History.Get (2), (Source_Address => 5, Source_Length => T.Scratch'Length - 4, Destination_Address => T'Address));
       Natural_Assert.Eq (T.Memory_Region_Length_Mismatch_History.Get_Count, 2);
-      Invalid_Memory_Region_Length_Assert.Eq (T.Memory_Region_Length_Mismatch_History.Get (2), (Region => (T.Scratch'Address, T.Scratch'Length), Expected_Length => T.Scratch'Length + 1));
+      Invalid_Memory_Region_Length_Assert.Eq (T.Memory_Region_Length_Mismatch_History.Get (2), (Region => (T.Scratch'Address, T.Scratch'Length), Expected_Length => 5 + (T.Scratch'Length - 4)));
 
       -- Check command response:
       Natural_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get_Count, 2);

--- a/src/components/memory_copier/test/memory_copier_tests-implementation.adb
+++ b/src/components/memory_copier/test/memory_copier_tests-implementation.adb
@@ -21,11 +21,59 @@ with System.Storage_Elements; use System.Storage_Elements;
 
 package body Memory_Copier_Tests.Implementation is
 
-   -- Globals to control task behavior. There is no thread safety here... but this
-   -- is testing code.
-   Task_Send_Response : Boolean := False;
-   Task_Send_Timeout : Boolean := False;
-   Task_Response : Memory_Enums.Memory_Copy_Status.E := Memory_Enums.Memory_Copy_Status.Success;
+   -- Protected object for thread-safe task control state shared between test and simulator task.
+   protected Task_State is
+      procedure Set_Send_Response (Value : in Boolean);
+      function Get_Send_Response return Boolean;
+      procedure Set_Send_Timeout (Value : in Boolean);
+      function Get_Send_Timeout return Boolean;
+      procedure Set_Response (Value : in Memory_Enums.Memory_Copy_Status.E);
+      function Get_Response return Memory_Enums.Memory_Copy_Status.E;
+      procedure Reset;
+   private
+      Send_Response : Boolean := False;
+      Send_Timeout : Boolean := False;
+      Response : Memory_Enums.Memory_Copy_Status.E := Memory_Enums.Memory_Copy_Status.Success;
+   end Task_State;
+
+   protected body Task_State is
+      procedure Set_Send_Response (Value : in Boolean) is
+      begin
+         Send_Response := Value;
+      end Set_Send_Response;
+
+      function Get_Send_Response return Boolean is
+      begin
+         return Send_Response;
+      end Get_Send_Response;
+
+      procedure Set_Send_Timeout (Value : in Boolean) is
+      begin
+         Send_Timeout := Value;
+      end Set_Send_Timeout;
+
+      function Get_Send_Timeout return Boolean is
+      begin
+         return Send_Timeout;
+      end Get_Send_Timeout;
+
+      procedure Set_Response (Value : in Memory_Enums.Memory_Copy_Status.E) is
+      begin
+         Response := Value;
+      end Set_Response;
+
+      function Get_Response return Memory_Enums.Memory_Copy_Status.E is
+      begin
+         return Response;
+      end Get_Response;
+
+      procedure Reset is
+      begin
+         Send_Response := False;
+         Send_Timeout := False;
+         Response := Memory_Enums.Memory_Copy_Status.Success;
+      end Reset;
+   end Task_State;
 
    -------------------------------------------------------------------------
    -- Fixtures:
@@ -34,9 +82,7 @@ package body Memory_Copier_Tests.Implementation is
    overriding procedure Set_Up_Test (Self : in out Instance) is
    begin
       -- Reset task state:
-      Task_Send_Response := False;
-      Task_Send_Timeout := False;
-      Task_Response := Memory_Enums.Memory_Copy_Status.Success;
+      Task_State.Reset;
 
       -- Allocate heap memory to component:
       Self.Tester.Init_Base (Queue_Size => Self.Tester.Component_Instance.Get_Max_Queue_Element_Size * 3);
@@ -85,20 +131,20 @@ package body Memory_Copier_Tests.Implementation is
          -- Increment variables:
          Cnt := @ + 1;
 
-         if Task_Send_Response then
+         if Task_State.Get_Send_Response then
             -- Send a valid response:
             Class_Self.all.Tester.Timeout_Tick_Send (((0, 0), 0)); -- send occasional timeout for coverage reasons
             Sleep (4);
-            Class_Self.all.Tester.Memory_Region_Release_T_Send ((Region => (Address => Sim_Bytes'Address, Length => Sim_Bytes'Length), Status => Task_Response));
-            Task_Send_Response := False;
-         elsif Task_Send_Timeout then
+            Class_Self.all.Tester.Memory_Region_Release_T_Send ((Region => (Address => Sim_Bytes'Address, Length => Sim_Bytes'Length), Status => Task_State.Get_Response));
+            Task_State.Set_Send_Response (False);
+         elsif Task_State.Get_Send_Timeout then
             -- Send a valid response:
             Sleep (4);
             Class_Self.all.Tester.Timeout_Tick_Send (((0, 0), 0));
             Tick_Count := @ + 1;
             if Tick_Count > 4 then
                Tick_Count := 0;
-               Task_Send_Timeout := False;
+               Task_State.Set_Send_Timeout (False);
             end if;
          else
             -- Sleep:
@@ -122,7 +168,7 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 5, Source_Length => 6, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Send_Response := True;
+      Task_State.Set_Send_Response (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 
@@ -147,7 +193,7 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => T.Scratch'Length, Destination_Address => Dest2'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Send_Response := True;
+      Task_State.Set_Send_Response (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 
@@ -183,8 +229,8 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => 5, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Response := Failure;
-      Task_Send_Response := True;
+      Task_State.Set_Response (Failure);
+      Task_State.Set_Send_Response (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 
@@ -219,7 +265,7 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => T.Scratch'Length, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Send_Timeout := True;
+      Task_State.Set_Send_Timeout (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 
@@ -288,7 +334,7 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => T.Scratch'Length + 1, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Send_Response := True;
+      Task_State.Set_Send_Response (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 
@@ -312,8 +358,8 @@ package body Memory_Copier_Tests.Implementation is
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 5, Source_Length => T.Scratch'Length - 4, Destination_Address => T'Address)));
 
       -- Execute the command and tell the task to respond.
-      Task_Response := Failure;
-      Task_Send_Response := True;
+      Task_State.Set_Response (Failure);
+      Task_State.Set_Send_Response (True);
       Natural_Assert.Eq (T.Dispatch_All, 1);
       Sleep (4);
 

--- a/src/components/memory_copier/test/memory_copier_tests-implementation.adb
+++ b/src/components/memory_copier/test/memory_copier_tests-implementation.adb
@@ -179,7 +179,7 @@ package body Memory_Copier_Tests.Implementation is
       Sim_Task : Simulator_Task (Self'Unchecked_Access, Task_Exit'Unchecked_Access);
       Dest : Basic_Types.Byte_Array (0 .. 99) := [others => 44];
    begin
-      -- Send command to copy region 1 byte too large:
+      -- Send command to copy region (will return failure status):
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => 5, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
@@ -215,7 +215,7 @@ package body Memory_Copier_Tests.Implementation is
       Sim_Task : Simulator_Task (Self'Unchecked_Access, Task_Exit'Unchecked_Access);
       Dest : Basic_Types.Byte_Array (0 .. 99) := [others => 44];
    begin
-      -- Send command to copy region 1 byte too large:
+      -- Send command to copy region (will time out):
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => T.Scratch'Length, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.
@@ -252,7 +252,7 @@ package body Memory_Copier_Tests.Implementation is
       -- Set scratch return status:
       T.Scratch_Return_Status := Memory_Manager_Enums.Memory_Request_Status.Failure;
 
-      -- Send command to copy region 1 byte too large:
+      -- Send command to copy region (memory will be unavailable):
       T.Command_T_Send (T.Commands.Copy_Memory_Region ((Source_Address => 0, Source_Length => T.Scratch'Length, Destination_Address => Dest'Address)));
 
       -- Execute the command and tell the task to respond.


### PR DESCRIPTION
1 CRITICAL (assert disabled in prod), 2 HIGH (address overflow, zero-length underflow). See `REVIEW.md`.