### PR TITLE
Code review: src/components/parameters/types

### DIFF
--- a/src/components/parameters/types/REVIEW.md
+++ b/src/components/parameters/types/REVIEW.md
@@ -1,0 +1,107 @@
+# Code Review: `src/components/parameters/types`
+
+**Reviewer:** Automated Ada/Adamant Expert Review  
+**Date:** 2026-03-01  
+**Package Type:** Types-only (no component, no body)
+
+---
+
+## 1. Package Specification Review
+
+### `parameters_component_types.ads`
+
+This hand-written spec defines `Parameter_Table_Entry` (a plain record, not packed) and an unconstrained array type plus access type.
+
+| # | Severity | Finding |
+|---|----------|---------|
+| S1 | **Medium** | **`Start_Index` / `End_Index` use `Natural` — no constraint prevents `End_Index < Start_Index`.** The record silently allows inverted ranges. A subtype or a postcondition-bearing constructor would prevent downstream off-by-one/empty-slice bugs. Any consumer that computes `Length := End_Index - Start_Index` without a guard risks `Constraint_Error` on underflow (Natural wraps to negative in subtraction context, caught at runtime, but the semantic intent is unclear). |
+| S2 | **Low** | **`Start_Index` / `End_Index` default to 0.** A default-initialized entry has `Start_Index = End_Index = 0`, which represents a zero-length parameter at index 0. This is a plausible sentinel, but it is undocumented. A brief comment or named constant (`Null_Entry`) would clarify intent. |
+| S3 | **Low** | **Access type `Parameter_Table_Entry_List_Access` is declared but usage scope is unclear.** Access types in safety-critical Ada are often avoided. Not necessarily wrong, but worth confirming it is needed (e.g., for a memory-mapped table). |
+| S4 | **Low** | **Array index is `Natural range <>`** — this means the lower bound is caller-chosen. If any consumer assumes 0-based or 1-based indexing, there could be a mismatch. Adamant convention appears to tolerate this, so flagged as informational only. |
+
+---
+
+## 2. Package Implementation Review
+
+No `.adb` file exists. This is expected for a types-only package with no subprogram bodies. **No findings.**
+
+---
+
+## 3. Model Review (YAML Record Files)
+
+### 3.1 `parameter_table_entry.record.yaml`
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M1 | **Medium** | **`Buffer` format uses Jinja template `U8x{{ parameter_buffer_size }}`** — the generated packed record size depends entirely on the build-time configuration constant `Configuration.Parameter_Buffer_Size` (currently 32). If a deployment overrides this to a large value, the resulting packed type could exceed expected telemetry packet sizes. There is no upper-bound guard in the YAML. This is by-design for Adamant's configurability but worth documenting the coupling. |
+| M2 | **Low** | **`variable_length: Header.Buffer_Length`** — correct usage, allowing serialized size to be smaller than the full buffer. No issue. |
+
+### 3.2 `parameter_table_entry_header.record.yaml`
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M3 | **Low** | `Buffer_Length` format is `U8`, matching `Parameter_Buffer_Length_Type` which ranges `0 .. Parameter_Buffer_Size` (currently 32). If `Parameter_Buffer_Size` ever exceeds 255, U8 will be insufficient. The current value (32) is safe; this is a latent coupling. |
+
+### 3.3 `packed_table_operation_status.record.yaml`
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M4 | **High** | **`Active_Table_Version_Number` is `Short_Float` (F32).** Using IEEE 754 single-precision float for a version number is semantically unusual. Floats cannot exactly represent all version-like values (e.g., 1.1 ≠ 1.1 in IEEE 754). If this is used for equality comparison anywhere downstream (e.g., "is version X loaded?"), it will be unreliable due to representation error. A fixed-point type or two separate integer fields (major.minor) would be safer. If this is a legacy/external interface constraint, it should be documented. |
+| M5 | **Medium** | **`Active_Table_Update_Time` is `Interfaces.Unsigned_32` (seconds).** This is a raw U32 timestamp with no epoch documentation. It will wrap around ~136 years from epoch, but more importantly, consumers cannot interpret the value without knowing the epoch. A description noting the epoch (e.g., "seconds since boot" or "seconds since J2000") would prevent misinterpretation. |
+
+### 3.4 `parameter_entry_comparison.record.yaml`
+
+No issues. All three fields are U16-formatted IDs matching their underlying 0..65535 ranges. Clean and correct.
+
+### 3.5 `invalid_parameter_length.record.yaml` / `invalid_parameter_table_entry_length.record.yaml`
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M6 | **Low** | `Expected_Length` is `Natural` formatted as `U32`. `Natural` on a 32-bit target is `0 .. 2**31-1`, but U32 can hold `0 .. 2**32-1`. The Adamant generator likely handles this correctly (constraining to Natural's range), but the mismatch between the Ada type and the wire format is worth noting. |
+| M7 | **Low** | Description says "packet length bound" in `invalid_parameter_length` but "parameter length bound" in `invalid_parameter_table_entry_length`. The latter is about table entries, not packets. Both descriptions are accurate for their contexts. No issue. |
+
+### 3.6 32-bit / 64-bit Subdirectories
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M8 | **Medium** | **All four YAML files are byte-for-byte identical between `32bit/` and `64bit/`.** The differentiation comes from `Memory_Region.T` resolving to different sizes per platform — the YAML content itself is duplicated. This is the standard Adamant pattern for platform-dependent types, but it creates a **maintenance hazard**: if one copy is updated and the other forgotten, silent divergence occurs. A comment in each file (or a shared template) would mitigate this risk. |
+
+### 3.7 `parameters_memory_region.record.yaml` (both variants)
+
+No issues. `Operation` as `E8` is appropriate for a small enumeration.
+
+### 3.8 `parameters_memory_region_release.record.yaml` (both variants)
+
+No issues. Clean pairing of region + status.
+
+### 3.9 `invalid_parameters_memory_region_crc.record.yaml` (both variants)
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M9 | **Low** | `skip_validation: True` and `byte_image: True` on the CRC field are correct — CRC values shouldn't be range-validated after deserialization. Proper usage. |
+
+---
+
+## 4. Unit Test Review
+
+**No unit tests exist in this package.** There are no `.adb` test files, no `test/` subdirectory, and no test-related files.
+
+| # | Severity | Finding |
+|---|----------|---------|
+| T1 | **Low** | No unit tests. For a types-only package with no logic, this is acceptable. The generated packed record serialization/deserialization is tested by the Adamant framework's own generator tests. The hand-written `Parameters_Component_Types` has no subprograms to test. |
+
+---
+
+## 5. Summary — Top 5 Findings
+
+| Rank | ID | Severity | Finding |
+|------|-----|----------|---------|
+| 1 | M4 | **High** | `Active_Table_Version_Number` uses `Short_Float` — IEEE 754 equality comparisons on version numbers are unreliable. Potential for silent version mismatch if compared downstream. |
+| 2 | S1 | **Medium** | `Start_Index` / `End_Index` in `Parameter_Table_Entry` have no invariant preventing inverted ranges. |
+| 3 | M8 | **Medium** | 32-bit and 64-bit YAML files are identical copies — maintenance hazard if one is updated without the other. |
+| 4 | M5 | **Medium** | `Active_Table_Update_Time` timestamp has no documented epoch, risking misinterpretation. |
+| 5 | M1 | **Medium** | `parameter_table_entry` buffer size is coupled to a build config constant with no documented upper bound constraint. |
+
+### Overall Assessment
+
+This is a clean, minimal types package. The most actionable finding is **M4** (float version number), which could cause real defects if version equality is checked anywhere in the system. The remaining findings are medium/low-severity maintenance and documentation improvements.


### PR DESCRIPTION
## Summary
Automated code review for `src/components/parameters/types`.

- **Type**: Ada Package (YAML type models)
- **Review file**: `src/components/parameters/types/REVIEW.md`
- **Review only** — YAML model changes too impactful for automated fixes

## Top Finding
- **High**: `Active_Table_Version_Number` uses `Short_Float` — IEEE 754 equality on version numbers is unreliable

---
Generated by the Adamant Full Review Pipeline