### PR TITLE
Code review: src/components/pid_controller

### DIFF
--- a/src/components/pid_controller/REVIEW.md
+++ b/src/components/pid_controller/REVIEW.md
@@ -1,0 +1,57 @@
+# PID Controller Component — Code Review
+
+**Reviewer:** Automated Review  
+**Date:** 2026-03-01  
+**Component:** `src/components/pid_controller`
+
+---
+
+## 1. Documentation Review
+
+| # | Severity | Finding |
+|---|----------|---------|
+| D1 | Low | The `pid_controller.tests.yaml` description for `Test_Pid_Controller` is incomplete: *"This test is a basic test to make sure that the controller"* — sentence is truncated. |
+| D2 | Low | The diagnostic subpacket record fields use the name `Measured_Angle`, `Reference_Angle`, and `Current_Out_Angle`, but the component description and control interface speak in terms of generic "values" (Commanded_Value, Measured_Value, Output_Value). The angle-specific naming leaks a domain assumption into a supposedly generic PID component. |
+| D3 | Low | The `pid_controller.packets.yaml` packet entry for `Pid_Controller_Diagnostic_Packet` has no `type` field defining the packet structure. The packet buffer is manually constructed at runtime. While functional, this bypasses Adamant's packet auto-generation and makes the packet format implicit rather than declarative. |
+
+## 2. Model Review
+
+| # | Severity | Finding |
+|---|----------|---------|
+| M1 | Medium | **`Moving_Average_Init_Samples` is `Integer` but semantically must be ≥ −1.** The init parameter accepts any `Integer`. Passing values like −2 or `Integer'First` is not validated; the behavior depends entirely on the `Moving_Average` library. There is no range constraint or precondition check. |
+| M2 | Medium | **No validation that `I_Min_Limit ≤ I_Max_Limit`.** The `Validate_Parameters` function unconditionally returns `Valid`. If a user sets `I_Min_Limit > I_Max_Limit`, the integral clamping logic becomes a no-op (the value will satisfy neither branch of the if/elsif), allowing unbounded integral windup — the very thing the limits are meant to prevent. |
+| M3 | Low | All six PID parameters default to 0.0 (gains) or ±`Short_Float'Large` (limits). With all gains at zero, the output is purely the feed-forward value. This is safe but may surprise users who expect non-zero defaults. The `Short_Float'Large` default for limits is effectively "no limit," which is acceptable but could mask a missing configuration. |
+
+## 3. Component Implementation Review
+
+| # | Severity | Finding |
+|---|----------|---------|
+| C1 | **Critical** | **Derivative filter can diverge.** The derivative term is computed as: `D_out = D_prev * (1.0 - N * dt) + (error - error_prev) * D_gain * N`. If `N_Filter * Time_Step > 2.0` (e.g., N=500 at 100 Hz → N·dt=5.0), the factor `(1.0 - N·dt)` becomes a large negative number, causing the derivative term to oscillate with growing amplitude each cycle. This is a discrete-time stability issue — the bilinear (Tustin) or backward-Euler discretization would be safe, but the forward-Euler form used here is conditionally unstable. For a safety-critical controller, this can cause actuator runaway. There is no runtime check or parameter validation on the N_Filter value relative to the time step. |
+| C2 | **High** | **Integral term uses previous-cycle error (backward integration), but first-iteration integral is always zero regardless of initial error magnitude.** On the first call (`First_Iteration = True`), `Control_Error_Prev` is reset to 0, so the integral contribution on that cycle is `I_Gain * dt * 0.0 = 0.0`. This is technically correct for a fresh start, but the integral uses `Control_Error_Prev` (rectangular/backward Euler), meaning the *current* cycle's error is never integrated until the *next* cycle. Combined with the derivative term also using the previous error, the very first control output after `First_Iteration` is only `P * error + feed_forward` — the I and D terms are always one step delayed. This is a known property of this discretization but is not documented. |
+| C3 | **High** | **`Short_Float` (32-bit IEEE 754) precision for integral accumulation.** The integral term accumulates over potentially thousands of cycles. With `Short_Float` providing ~7 decimal digits of precision, a large accumulated integral (e.g., near the windup limit) plus a small `I_Gain * dt * error` increment can lose significance. For long-running controllers this can cause the integrator to "stick" — new small errors no longer change the accumulated value. Using `Float` (also 32-bit on most targets) or `Long_Float` (64-bit) for the accumulator would mitigate this. |
+| C4 | Medium | **`Init` uses `pragma Assert` for `Control_Frequency > 0.0`.** In production builds with assertions disabled (`-gnatp`), a zero or negative frequency would silently produce `Time_Step = +Inf` or `NaN`, leading to nonsensical control outputs. A proper runtime check raising `Constraint_Error` or a dedicated exception would be safer. |
+| C5 | Medium | **No NaN/Inf guard on inputs or outputs.** If `Measured_Value` or `Commanded_Value` is NaN (e.g., from a failed sensor), all subsequent computations propagate NaN silently. The control output will be NaN, which is sent downstream. Safety-critical controllers typically check for non-finite values and enter a safe fallback mode. |
+| C6 | Medium | **Diagnostic packet buffer index is 0-based with manual offset arithmetic.** The computation `Diagnostic_Packet_Index := (Diagnostic_Subpacket_Count * Subpacket_Length) + Header_Length` is correct but fragile. An off-by-one in subpacket count or a change to the subpacket size could cause buffer overrun. The overflow check `(index + subpacket_size) > Buffer'Length` prevents writing past the end, but the logic is subtle and has no defensive assertion. |
+| C7 | Low | **`Diagnostic_Counter` is a protected decrementing counter but `Diag_Count` is read via `Get_Count` and then separately decremented.** Between the `Get_Count` and `Decrement_Count` calls, if this component were ever invoked from multiple tasks (currently it's `recv_sync` so single-threaded), a TOCTOU race would exist. Currently safe due to the synchronous connector model, but the use of a protected counter for a single-threaded path is misleading. |
+
+## 4. Unit Test Review
+
+| # | Severity | Finding |
+|---|----------|---------|
+| T1 | **High** | **No test for derivative filter stability/instability.** Given the critical finding C1, there is no test that exercises a large `N_Filter` value relative to the control frequency. A test with `N_Filter` such that `N * dt > 1.0` would immediately reveal divergent behavior. |
+| T2 | **High** | **No test for `I_Min_Limit > I_Max_Limit` (inverted limits).** Per finding M2, this misconfiguration silently disables windup protection. A test should verify the component either rejects or handles this gracefully. |
+| T3 | Medium | **`Set_Up_Test` has the `Init` call commented out.** Each test body calls `Init` individually, which is fine, but the commented-out line `--Self.Tester.Component_Instance.Init(...)` in `Set_Up_Test` is dead code that could confuse maintainers about whether setup is complete. |
+| T4 | Medium | **No test for NaN/Inf input behavior.** There are no tests that feed `Short_Float'Last`, `0.0/0.0`, or other edge-case floating-point values to verify the component doesn't produce unsafe outputs. |
+| T5 | Medium | **No test for `Control_Frequency` edge cases in `Init`.** Zero, negative, and very small frequencies are not tested. The `pragma Assert` is the only guard (see C4). |
+| T6 | Low | **`Test_Pid_Controller` uses magic numbers for expected outputs (13.0, 48.794, -109.53).** These are hand-calculated but not documented in comments showing the derivation. If the PID algorithm changes, it's unclear whether these values are still correct. |
+| T7 | Low | **No test for `Destroy` of `Protected_Moving_Average`.** `Tear_Down_Test` calls `Final_Base` on the tester but does not explicitly verify that the moving average memory is freed. If `Moving_Average` allocates heap memory, a leak could go undetected. |
+
+## 5. Summary — Top 5 Findings
+
+| Rank | ID | Severity | Finding |
+|------|----|----------|---------|
+| 1 | C1 | **Critical** | Derivative filter uses forward-Euler discretization that is unstable when `N_Filter * Time_Step > 2.0`. No validation prevents this, risking actuator runaway. |
+| 2 | M2 | **High** | `Validate_Parameters` does not check `I_Min_Limit ≤ I_Max_Limit`. Inverted limits silently disable integral windup protection. |
+| 3 | C3 | **High** | 32-bit `Short_Float` integral accumulator loses precision over long control runs, causing the integrator to "stick" and stop responding to small errors. |
+| 4 | C5 | Medium | No NaN/Inf detection on inputs or outputs. A failed sensor propagates NaN through the entire control chain silently. |
+| 5 | T1 | **High** | No unit test exercises the derivative filter stability boundary, leaving the critical C1 defect undetectable by the test suite. |

--- a/src/components/pid_controller/REVIEW.md
+++ b/src/components/pid_controller/REVIEW.md
@@ -55,3 +55,16 @@
 | 3 | C3 | **High** | 32-bit `Short_Float` integral accumulator loses precision over long control runs, causing the integrator to "stick" and stop responding to small errors. |
 | 4 | C5 | Medium | No NaN/Inf detection on inputs or outputs. A failed sensor propagates NaN through the entire control chain silently. |
 | 5 | T1 | **High** | No unit test exercises the derivative filter stability boundary, leaving the critical C1 defect undetectable by the test suite. |
+
+## Resolution Notes
+
+| # | Issue | Severity | Status | Commit | Notes |
+|---|-------|----------|--------|--------|-------|
+| 1 | Derivative filter stability validation | Critical | Fixed | 2a02256 | Added N*dt >= 2.0 check in Validate_Parameters |
+| 2 | Validate I_Min_Limit <= I_Max_Limit | High | Fixed | 33f0960 | Added validation in Validate_Parameters |
+| 3 | Document one-step I/D delay | High | Fixed | d08701e | Added comment documenting first-iteration behavior |
+| 4 | Use Long_Float for integral accumulator | High | Fixed | e49a5a8 | Changed accumulator from Short_Float to Long_Float |
+| 5 | Add stability/limits tests | High | Fixed | abd0258 | Added Test_Derivative_Filter_Stability and Test_Inverted_Integral_Limits |
+| 6 | Validate Moving_Average_Init_Samples | Medium | Fixed | 87b17ee | Added >= -1 validation |
+| 7 | Replace pragma Assert for Control_Frequency | Medium | Fixed | 9b08a09 | Explicit runtime check |
+| 8 | Add NaN/Inf guard on control inputs | Medium | Fixed | a8bff1d | Guard added to reject non-finite inputs |

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -115,19 +115,24 @@ package body Component.Pid_Controller.Implementation is
          Pid_Control_Error : constant Short_Float := Arg.Commanded_Value - Arg.Measured_Value;
          -- Proportional control
          Pid_Proportional_Output : constant Short_Float := Self.P_Gain.Value * Pid_Control_Error;
-         -- Integral control
-         Pid_Integral_Output : Short_Float := Self.Control_Out_Prev_I + Self.I_Gain.Value * Self.Time_Step * Self.Control_Error_Prev;
+         -- Integral control - accumulate in Long_Float to preserve precision (C3),
+         -- then convert to Short_Float for the control output computation.
+         Pid_Integral_Accum : Long_Float := Self.Control_Out_Prev_I + Long_Float (Self.I_Gain.Value * Self.Time_Step * Self.Control_Error_Prev);
+         Pid_Integral_Output : Short_Float;
          -- Derivative control
          Pid_Derivative_Output : constant Short_Float := Self.Control_Out_Prev_D * (1.0 - (Self.N_Filter.Value * Self.Time_Step)) + (Pid_Control_Error - Self.Control_Error_Prev) * Self.D_Gain.Value * Self.N_Filter.Value;
          -- Total control output
          Pid_Control_Output : Short_Float;
       begin
          -- Limit integral wind up based on our integral limit parameters:
-         if Pid_Integral_Output > Self.I_Max_Limit.Value then
-            Pid_Integral_Output := Self.I_Max_Limit.Value;
-         elsif Pid_Integral_Output < Self.I_Min_Limit.Value then
-            Pid_Integral_Output := Self.I_Min_Limit.Value;
+         if Pid_Integral_Accum > Long_Float (Self.I_Max_Limit.Value) then
+            Pid_Integral_Accum := Long_Float (Self.I_Max_Limit.Value);
+         elsif Pid_Integral_Accum < Long_Float (Self.I_Min_Limit.Value) then
+            Pid_Integral_Accum := Long_Float (Self.I_Min_Limit.Value);
          end if;
+
+         -- Convert accumulated integral to Short_Float for output:
+         Pid_Integral_Output := Short_Float (Pid_Integral_Accum);
 
          -- Set the control output after we limit the integral term
          Pid_Control_Output := Pid_Proportional_Output + Pid_Integral_Output + Pid_Derivative_Output + Arg.Feed_Forward_Value;
@@ -138,7 +143,7 @@ package body Component.Pid_Controller.Implementation is
          -- Update the previous values here
          Self.Control_Error_Prev := Pid_Control_Error;
          Self.Control_Out_Prev_D := Pid_Derivative_Output;
-         Self.Control_Out_Prev_I := Pid_Integral_Output;
+         Self.Control_Out_Prev_I := Pid_Integral_Accum;
 
          -- Calculate the new statistics for this cycle if the object was initialized
          if Self.Use_Ma_Stats then

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -107,6 +107,19 @@ package body Component.Pid_Controller.Implementation is
       --
       -- Use the updated parameters to calculate the control output.
       --
+      -- C5: Guard against NaN/Inf inputs from failed sensors. If either input
+      -- is non-finite, skip control computation and output the feed-forward value
+      -- as a safe fallback to avoid propagating NaN through the control chain.
+      if not (Arg.Commanded_Value'Valid and then Arg.Measured_Value'Valid and then Arg.Feed_Forward_Value'Valid) then
+         -- Output only the feed-forward if it is valid, otherwise output 0.0
+         if Arg.Feed_Forward_Value'Valid then
+            Self.Control_Output_U_Send_If_Connected ((Time => Arg.Time, Output_Value => Arg.Feed_Forward_Value, Error => 0.0));
+         else
+            Self.Control_Output_U_Send_If_Connected ((Time => Arg.Time, Output_Value => 0.0, Error => 0.0));
+         end if;
+         return;
+      end if;
+
       -- Note on discretization: The integral and derivative terms use backward-Euler
       -- (rectangular) integration with the *previous* cycle's error. This means on the
       -- very first iteration after First_Iteration=True, only P*error + feed_forward

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -53,7 +53,11 @@ package body Component.Pid_Controller.Implementation is
    overriding procedure Init (Self : in out Instance; Control_Frequency : in Short_Float; Database_Update_Period : in Unsigned_16; Moving_Average_Max_Samples : in Natural; Moving_Average_Init_Samples : in Integer := -1) is
    begin
       -- Set the control time step (period):
-      pragma Assert (Control_Frequency > 0.0, "The control frequency must be a positive floating point value.");
+      -- C4: Use a proper runtime check instead of pragma Assert, which can be
+      -- disabled in production builds with -gnatp, silently producing Inf/NaN.
+      if not (Control_Frequency > 0.0) then
+         raise Constraint_Error with "The control frequency must be a positive floating point value.";
+      end if;
       Self.Time_Step := 1.0 / Control_Frequency;
 
       -- Set the database update period:

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -302,4 +302,34 @@ package body Component.Pid_Controller.Implementation is
       Self.Event_T_Send_If_Connected (Self.Events.Invalid_Parameter_Received (Self.Sys_Time_T_Get, (Id => Par.Header.Id, Errant_Field_Number => Errant_Field_Number, Errant_Field => Errant_Field)));
    end Invalid_Parameter;
 
+   -----------------------------------------------
+   -- Parameter validation:
+   -----------------------------------------------
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      P_Gain : in Packed_F32.U;
+      I_Gain : in Packed_F32.U;
+      D_Gain : in Packed_F32.U;
+      N_Filter : in Packed_F32.U;
+      I_Min_Limit : in Packed_F32.U;
+      I_Max_Limit : in Packed_F32.U
+   ) return Parameter_Validation_Status.E is
+      pragma Unreferenced (P_Gain, I_Gain, D_Gain);
+   begin
+      -- C1: Validate derivative filter stability. The forward-Euler discretization
+      -- of the derivative filter is unstable when N_Filter * Time_Step >= 2.0.
+      -- Reject parameters that would cause this condition.
+      if N_Filter.Value * Self.Time_Step >= 2.0 then
+         return Parameter_Validation_Status.Invalid;
+      end if;
+
+      -- M2: Validate that I_Min_Limit <= I_Max_Limit. Inverted limits would
+      -- silently disable integral windup protection.
+      if I_Min_Limit.Value > I_Max_Limit.Value then
+         return Parameter_Validation_Status.Invalid;
+      end if;
+
+      return Parameter_Validation_Status.Valid;
+   end Validate_Parameters;
+
 end Component.Pid_Controller.Implementation;

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -62,7 +62,12 @@ package body Component.Pid_Controller.Implementation is
       Self.Diagnostic_Counter.Set_Count (0);
 
       -- Setup the moving average object if the max size is set to something other than 0
+      -- M1: Validate that Moving_Average_Init_Samples is >= -1 (where -1 means "use max").
+      -- Values less than -1 are not meaningful and could cause undefined behavior.
       if Moving_Average_Max_Samples > 0 then
+         if Moving_Average_Init_Samples < -1 then
+            raise Constraint_Error with "Moving_Average_Init_Samples must be >= -1, got" & Integer'Image (Moving_Average_Init_Samples);
+         end if;
          Self.Ma_Stats.Init (Sample_Storage_Size => Moving_Average_Max_Samples, Sample_Calculation_Size => Moving_Average_Init_Samples);
          Self.Use_Ma_Stats := True;
       else

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -96,7 +96,13 @@ package body Component.Pid_Controller.Implementation is
       end if;
 
       --
-      -- Use the updated parameters to calculate the control angle we desire
+      -- Use the updated parameters to calculate the control output.
+      --
+      -- Note on discretization: The integral and derivative terms use backward-Euler
+      -- (rectangular) integration with the *previous* cycle's error. This means on the
+      -- very first iteration after First_Iteration=True, only P*error + feed_forward
+      -- contributes to the output; the I and D terms are effectively one step delayed.
+      -- This is a known and intentional property of this discretization scheme.
       --
       declare
          -- Pull out the timestamp from the input data for ease of use:

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -234,6 +234,12 @@ package body Component.Pid_Controller.Implementation is
                   Self.Diagnostic_Packet.Header.Time := Timestamp;
                end if;
 
+               -- C6: Defensive assertion to catch buffer overrun before it happens.
+               -- The overflow check above should prevent this, but an explicit assertion
+               -- makes the invariant clear and catches logic errors during development.
+               pragma Assert (Diagnostic_Packet_Index + Pid_Diagnostic_Subpacket.Max_Serialized_Length <= Self.Diagnostic_Packet.Buffer'Length,
+                  "Diagnostic packet buffer overrun: index would exceed buffer bounds");
+
                -- Fill the packet buffer with diagnostic data from this cycle:
                Self.Diagnostic_Packet.Buffer (Diagnostic_Packet_Index .. Diagnostic_Packet_Index + Pid_Diagnostic_Subpacket.Max_Serialized_Length - 1) :=
                   Pid_Diagnostic_Subpacket.Serialization.To_Byte_Array ((Measured_Angle => Arg.Measured_Value, Reference_Angle => Arg.Commanded_Value, Current_Out_Angle => Pid_Control_Output));

--- a/src/components/pid_controller/component-pid_controller-implementation.ads
+++ b/src/components/pid_controller/component-pid_controller-implementation.ads
@@ -147,6 +147,6 @@ private
       N_Filter : in Packed_F32.U;
       I_Min_Limit : in Packed_F32.U;
       I_Max_Limit : in Packed_F32.U
-   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
+   ) return Parameter_Validation_Status.E;
 
 end Component.Pid_Controller.Implementation;

--- a/src/components/pid_controller/component-pid_controller-implementation.ads
+++ b/src/components/pid_controller/component-pid_controller-implementation.ads
@@ -55,7 +55,10 @@ private
 
       -- Previous integral and derivative values
       Control_Error_Prev : Short_Float := 0.0;
-      Control_Out_Prev_I : Short_Float := 0.0;
+      -- Use Long_Float (64-bit) for the integral accumulator to avoid
+      -- precision loss over long control runs (C3). Small I_Gain*dt*error
+      -- increments can be lost when added to a large Short_Float accumulator.
+      Control_Out_Prev_I : Long_Float := 0.0;
       Control_Out_Prev_D : Short_Float := 0.0;
 
       -- Diagnostic packet variables

--- a/src/components/pid_controller/test/pid_controller.tests.yaml
+++ b/src/components/pid_controller/test/pid_controller.tests.yaml
@@ -19,4 +19,8 @@ tests:
     description: This unit test exercises updating the length of the array used to calculate statistics and thus the duration of the statistic period.
   - name: Test_Moving_Average_Unused
     description: This test makes sure that if the moving_average object is unused, that no statistics come out and nothing breaks.
+  - name: Test_Derivative_Filter_Stability
+    description: This unit test verifies that parameter validation rejects N_Filter values that would cause derivative filter instability (N*dt >= 2.0).
+  - name: Test_Inverted_Integral_Limits
+    description: This unit test verifies that parameter validation rejects inverted integral limits (I_Min_Limit > I_Max_Limit).
 

--- a/src/components/pid_controller/test/pid_controller_tests-implementation.adb
+++ b/src/components/pid_controller/test/pid_controller_tests-implementation.adb
@@ -546,4 +546,84 @@ package body Pid_Controller_Tests.Implementation is
 
    end Test_Moving_Average_Unused;
 
+   overriding procedure Test_Derivative_Filter_Stability (Self : in out Instance) is
+      T : Component.Pid_Controller.Implementation.Tester.Instance_Access renames Self.Tester;
+      Status : Parameter_Enums.Parameter_Update_Status.E;
+      Param : Parameter.T;
+      pragma Unreferenced (Param);
+   begin
+      Put_Line ("");
+      Put_Line ("----------------------------------");
+      Put_Line ("Testing Derivative Filter Stability Validation:");
+      Put_Line ("----------------------------------");
+
+      -- Init at 100 Hz => dt = 0.01s
+      Self.Tester.Component_Instance.Init (Control_Frequency => 100.0, Database_Update_Period => 3, Moving_Average_Max_Samples => 10, Moving_Average_Init_Samples => 5);
+
+      -- N_Filter = 200.0 => N*dt = 2.0, which is at the instability boundary.
+      -- This should be rejected by Validate_Parameters.
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.N_Filter ((Value => 200.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_N_Filter_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+
+      -- Attempt to update - should fail validation
+      Parameter_Update_Status_Assert.Eq (Self.Tester.Update_Parameters, Validation_Error);
+
+      -- N_Filter = 500.0 => N*dt = 5.0, well beyond instability. Should be rejected.
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.N_Filter ((Value => 500.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_N_Filter_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Parameter_Update_Status_Assert.Eq (Self.Tester.Update_Parameters, Validation_Error);
+
+      -- N_Filter = 100.0 => N*dt = 1.0, stable. Should be accepted.
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.N_Filter ((Value => 100.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_N_Filter_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Parameter_Update_Status_Assert.Eq (Self.Tester.Update_Parameters, Success);
+
+   end Test_Derivative_Filter_Stability;
+
+   overriding procedure Test_Inverted_Integral_Limits (Self : in out Instance) is
+      T : Component.Pid_Controller.Implementation.Tester.Instance_Access renames Self.Tester;
+      Status : Parameter_Enums.Parameter_Update_Status.E;
+      Param : Parameter.T;
+      pragma Unreferenced (Param);
+   begin
+      Put_Line ("");
+      Put_Line ("----------------------------------");
+      Put_Line ("Testing Inverted Integral Limits Validation:");
+      Put_Line ("----------------------------------");
+
+      Self.Tester.Component_Instance.Init (Control_Frequency => 100.0, Database_Update_Period => 3, Moving_Average_Max_Samples => 10, Moving_Average_Init_Samples => 5);
+
+      -- Set I_Min_Limit > I_Max_Limit (inverted). Should be rejected.
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.I_Min_Limit ((Value => 10.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_I_Min_Limit_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.I_Max_Limit ((Value => -10.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_I_Max_Limit_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+
+      -- Attempt to update - should fail validation
+      Parameter_Update_Status_Assert.Eq (Self.Tester.Update_Parameters, Validation_Error);
+
+      -- Now set valid limits (min < max). Should succeed.
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.I_Min_Limit ((Value => -5.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_I_Min_Limit_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Stage_Parameter (Self.Tester.Parameters.I_Max_Limit ((Value => 5.0)));
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+      Status := Self.Tester.Fetch_Parameter (Self.Tester.Parameters.Get_I_Max_Limit_Id, Param);
+      Parameter_Update_Status_Assert.Eq (Status, Success);
+
+      Parameter_Update_Status_Assert.Eq (Self.Tester.Update_Parameters, Success);
+
+   end Test_Inverted_Integral_Limits;
+
 end Pid_Controller_Tests.Implementation;

--- a/src/components/pid_controller/test/pid_controller_tests-implementation.ads
+++ b/src/components/pid_controller/test/pid_controller_tests-implementation.ads
@@ -29,6 +29,10 @@ private
    overriding procedure Test_Set_Controller_Statistic_Duration_Command (Self : in out Instance);
    -- This test makes sure that if the moving_average object is unused, that no statistics come out and nothing breaks.
    overriding procedure Test_Moving_Average_Unused (Self : in out Instance);
+   -- This unit test verifies that parameter validation rejects N_Filter values that would cause derivative filter instability (N*dt >= 2.0).
+   overriding procedure Test_Derivative_Filter_Stability (Self : in out Instance);
+   -- This unit test verifies that parameter validation rejects inverted integral limits (I_Min_Limit > I_Max_Limit).
+   overriding procedure Test_Inverted_Integral_Limits (Self : in out Instance);
 
    -- Test data and state:
    type Instance is new Pid_Controller_Tests.Base_Instance with record


### PR DESCRIPTION
## Summary
Automated code review for `src/components/pid_controller`.

- **Type**: Component
- **Review file**: `src/components/pid_controller/REVIEW.md`

## Critical Finding
- **Derivative filter instability**: Forward-Euler discretization diverges when `N_Filter × Time_Step > 2.0` — no parameter validation prevents this

## Other Key Findings
- Inverted integral limits silently disable windup protection
- 32-bit float integral accumulator loses precision over time
- No NaN/Inf guards on control output

---
Generated by the Adamant Full Review Pipeline