### PR TITLE
FIXES - Code review: command_router/router_table

### DIFF
--- a/src/components/command_router/router_table/router_table.adb
+++ b/src/components/command_router/router_table/router_table.adb
@@ -58,6 +58,8 @@ package body Router_Table is
    begin
       -- Using ID, binary search the table ranges to find the correct entry:
       if not Self.Table.Search (Registration_To_Find, Registration_Found, Ignore) then
+         -- Sentinel: Registration_Id is set to 'Last on failure.
+         -- Callers MUST check the return status before using Registration_Id.
          Registration_Id := Command_Types.Command_Registration_Id'Last;
          return Id_Not_Found;
       end if;

--- a/src/components/command_router/router_table/test/router_table.tests.yaml
+++ b/src/components/command_router/router_table/test/router_table.tests.yaml
@@ -3,3 +3,5 @@ description: This is a unit test suite for the router_table object
 tests:
   - name: Add_To_Table
     description: This unit test adds registration elements to the router table and asserts for correct table size and searching
+  - name: Single_Entry_Table
+    description: This unit test exercises the boundary condition of a table with capacity 1, verifying add, full, lookup, and destroy behavior

--- a/src/components/command_router/router_table/test/router_table_tests-implementation.adb
+++ b/src/components/command_router/router_table/test/router_table_tests-implementation.adb
@@ -69,20 +69,68 @@ package body Router_Table_Tests.Implementation is
       Registration_Assert.Eq (Registration_Id, 36);
       Natural_Assert.Eq (Self.Table.Get_Size, 3);
 
-      -- Search table for nonexistent registrations:
-      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (96, Ignore), Router_Table.Id_Not_Found);
+      -- Search table for nonexistent registrations, verify sentinel value:
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (96, Registration_Id), Router_Table.Id_Not_Found);
+      Registration_Assert.Eq (Registration_Id, Command_Types.Command_Registration_Id'Last);
       Natural_Assert.Eq (Self.Table.Get_Size, 3);
 
-      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (17, Ignore), Router_Table.Id_Not_Found);
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (17, Registration_Id), Router_Table.Id_Not_Found);
+      Registration_Assert.Eq (Registration_Id, Command_Types.Command_Registration_Id'Last);
       Natural_Assert.Eq (Self.Table.Get_Size, 3);
 
-      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (7, Ignore), Router_Table.Id_Not_Found);
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (7, Registration_Id), Router_Table.Id_Not_Found);
+      Registration_Assert.Eq (Registration_Id, Command_Types.Command_Registration_Id'Last);
       Natural_Assert.Eq (Self.Table.Get_Size, 3);
 
       -- Clear table:
       Self.Table.Clear;
       Natural_Assert.Eq (Self.Table.Get_Size, 0);
       Natural_Assert.Eq (Self.Table.Get_Capacity, 3);
+
+      -- Verify lookup fails after clear for previously-added entries:
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (0, Ignore), Router_Table.Id_Not_Found);
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (1, Ignore), Router_Table.Id_Not_Found);
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (19, Ignore), Router_Table.Id_Not_Found);
+
+      -- Verify re-add works after clear:
+      Status_Assert.Eq (Self.Table.Add ((Registration_Id => 5, Command_Id => 42)), Router_Table.Success);
+      Natural_Assert.Eq (Self.Table.Get_Size, 1);
+      Lookup_Assert.Eq (Self.Table.Lookup_Registration_Id (42, Registration_Id), Router_Table.Success);
+      Registration_Assert.Eq (Registration_Id, 5);
    end Add_To_Table;
+
+   overriding procedure Single_Entry_Table (Self : in out Instance) is
+      pragma Unreferenced (Self);
+      Tbl : Router_Table.Instance;
+      Registration_Id : Command_Types.Command_Registration_Id;
+   begin
+      -- Initialize table with minimum capacity of 1:
+      Tbl.Init (1);
+      Natural_Assert.Eq (Tbl.Get_Size, 0);
+      Natural_Assert.Eq (Tbl.Get_Capacity, 1);
+
+      -- Add single entry:
+      Status_Assert.Eq (Tbl.Add ((Registration_Id => 7, Command_Id => 99)), Router_Table.Success);
+      Natural_Assert.Eq (Tbl.Get_Size, 1);
+
+      -- Table should be full:
+      Status_Assert.Eq (Tbl.Add ((Registration_Id => 8, Command_Id => 100)), Router_Table.Table_Full);
+      Natural_Assert.Eq (Tbl.Get_Size, 1);
+
+      -- Duplicate should still be rejected:
+      Status_Assert.Eq (Tbl.Add ((Registration_Id => 9, Command_Id => 99)), Router_Table.Id_Conflict);
+
+      -- Lookup the single entry:
+      Lookup_Assert.Eq (Tbl.Lookup_Registration_Id (99, Registration_Id), Router_Table.Success);
+      Registration_Assert.Eq (Registration_Id, 7);
+
+      -- Lookup nonexistent entry:
+      Lookup_Assert.Eq (Tbl.Lookup_Registration_Id (100, Registration_Id), Router_Table.Id_Not_Found);
+      Registration_Assert.Eq (Registration_Id, Command_Types.Command_Registration_Id'Last);
+
+      pragma Warnings (Off, """Tbl"" modified by call, but value might not be referenced");
+      Tbl.Destroy;
+      pragma Warnings (On, """Tbl"" modified by call, but value might not be referenced");
+   end Single_Entry_Table;
 
 end Router_Table_Tests.Implementation;

--- a/src/components/command_router/router_table/test/router_table_tests-implementation.ads
+++ b/src/components/command_router/router_table/test/router_table_tests-implementation.ads
@@ -16,6 +16,9 @@ private
    -- This unit test adds registration elements to the router table and asserts for correct response and table structure
    overriding procedure Add_To_Table (Self : in out Instance);
 
+   -- This unit test exercises the boundary condition of a table with capacity 1
+   overriding procedure Single_Entry_Table (Self : in out Instance);
+
    -- Test data and state:
    type Instance is new Router_Table_Tests.Base_Instance with record
       Table : Router_Table.Instance_Access;


### PR DESCRIPTION
Cherry-picked fix commits from PR #47 with style warnings resolved.

**Commits:**
1. Fix High: Add post-Clear behavioral verification to tests
2. Fix Medium: Document sentinel value on failed lookup
3. Fix Medium: Add distinct test cases to test model
4. Fix Medium: Add boundary test for minimum table size of 1
5. Fix Low: Verify sentinel value on failed lookup paths
6. Fix style warnings in router_table tests (pragma Unreferenced, pragma Warnings for Destroy)