### PR TITLE
FIXES - Code review: event_limiter

### DIFF
--- a/src/components/event_limiter/component-event_limiter-implementation.adb
+++ b/src/components/event_limiter/component-event_limiter-implementation.adb
@@ -101,16 +101,16 @@ package body Component.Event_Limiter.Implementation is
    -- Init Parameters:
    -- Event_Id_Start : Event_Types.Event_Id - The event ID that begins the range of ids that the component will include for potential limiting of events.
    -- Event_Id_Stop : Event_Types.Event_Id - The event ID that ends the range of ids that the component will include for potential limiting of events.
-   -- Event_Disable_List : Two_Counter_Entry.Event_Id_List - A list of event IDs that are enabled by default
+   -- Event_Disable_List : Two_Counter_Entry.Event_Id_List - A list of event IDs that are disabled by default
    -- Event_Limit_Persistence : Two_Counter_Entry.Persistence_Type - The initial persistence of the number of events to allow before limiting them between ticks (1 to 7)
    --
    overriding procedure Init
       (Self : in out Instance; Event_Id_Start : in Event_Types.Event_Id; Event_Id_Stop : in Event_Types.Event_Id; Event_Disable_List : in Two_Counter_Entry.Event_Id_List := [1 .. 0 => 0]; Event_Limit_Persistence : in Two_Counter_Entry.Persistence_Type)
    is
    begin
-      Self.Event_Array.Init (Event_Id_Start, Event_Id_Stop, Event_Disable_List, Event_Limit_Persistence);
       -- This is asserted in the package as well but added here for extra clarity
       pragma Assert (Event_Id_Stop >= Event_Id_Start, "Stop id must be equal to or greater than the start ID for the event limiter");
+      Self.Event_Array.Init (Event_Id_Start, Event_Id_Stop, Event_Disable_List, Event_Limit_Persistence);
 
       -- Divide by 8 to determine the number of ids we need to accommodate (1 id per bit). Add eight since the difference needs to account for an extra byte if we have ids that need to fil up some of the next byte
       Self.State_Packet_Size := Natural (Event_Id_Stop - Event_Id_Start + 8) / 8;
@@ -124,7 +124,7 @@ package body Component.Event_Limiter.Implementation is
    ---------------------------------------
    -- Invokee connector primitives:
    ---------------------------------------
-   -- This is the base tick for the component. Upon reception the component will decrement the count of each ID unless it is already 0. Every 10 ticks, an event of what is filtered will be sent.
+   -- This is the base tick for the component. Upon reception the component will decrement the count of each ID unless it is already 0. Every tick, an event of what has been filtered will be sent.
    overriding procedure Tick_T_Recv_Sync (Self : in out Instance; Arg : in Tick.T) is
       use Event_State_Type;
       -- Get the timestamp for the package
@@ -149,7 +149,7 @@ package body Component.Event_Limiter.Implementation is
                   null; -- do nothing here and move on
                   -- Save the event id into our event that indicates this id was limited (if room is available)
                when Event_Max_Limit =>
-                  if Num_Event_Limited_Event.Num_Event_Ids <= Num_Event_Limited_Event.Event_Id_Limited_Array'Length then
+                  if Num_Event_Limited_Event.Num_Event_Ids < Num_Event_Limited_Event.Event_Id_Limited_Array'Length then
                      Num_Event_Limited_Event.Event_Id_Limited_Array (Integer (Num_Event_Limited_Event.Num_Event_Ids)) := Dec_Event_Id;
                      Num_Event_Limited_Event.Num_Event_Ids := @ + 1;
                   end if;
@@ -203,7 +203,7 @@ package body Component.Event_Limiter.Implementation is
                            Byte_Num := @ + 1;
                      end case;
                   when Invalid_Id =>
-                     pragma Assert (False, "Invalid_Id found when decrementing all event limiter counters which should not be possible: " & Natural'Image (Natural (Id)));
+                     pragma Assert (False, "Invalid_Id found when getting enable state for event limiter state packet which should not be possible: " & Natural'Image (Natural (Id)));
                end case;
             end loop;
             -- Finish the last byte of the packet if necessary
@@ -428,7 +428,7 @@ package body Component.Event_Limiter.Implementation is
       return Success;
    end Disable_Event_Limiting;
 
-   -- Change the persistence of the event limiter for all events that are limited. Value must be between 0 and 7.
+   -- Change the persistence of the event limiter for all events that are limited. Value must be between 1 and 7.
    overriding function Set_Event_Limit_Persistence (Self : in out Instance; Arg : in Event_Limiter_Persistence_Type.T) return Command_Execution_Status.E is
       use Command_Execution_Status;
    begin

--- a/src/components/event_limiter/component-event_limiter-implementation.ads
+++ b/src/components/event_limiter/component-event_limiter-implementation.ads
@@ -82,7 +82,7 @@ private
    ---------------------------------------
    -- Invokee connector primitives:
    ---------------------------------------
-   -- This is the base tick for the component. Upon reception the component will decrement the count of each ID unless it is already 0. Every 10 ticks, an event of what is filtered will be sent.
+   -- This is the base tick for the component. Upon reception the component will decrement the count of each ID unless it is already 0. Every tick, an event of what has been filtered will be sent.
    overriding procedure Tick_T_Recv_Sync (Self : in out Instance; Arg : in Tick.T);
    -- Events are received synchronously on this connector and checked for the number of events of that ID.
    overriding procedure Event_T_Recv_Sync (Self : in out Instance; Arg : in Event.T);
@@ -120,7 +120,7 @@ private
    overriding function Enable_Event_Limiting (Self : in out Instance) return Command_Execution_Status.E;
    -- Disable the event limiters for all event IDs.
    overriding function Disable_Event_Limiting (Self : in out Instance) return Command_Execution_Status.E;
-   -- Set the persistence of the event limiter for all events that are limited. Value must be between 0 and 7.
+   -- Set the persistence of the event limiter for all events that are limited. Value must be between 1 and 7.
    overriding function Set_Event_Limit_Persistence (Self : in out Instance; Arg : in Event_Limiter_Persistence_Type.T) return Command_Execution_Status.E;
    -- Dump a packet for the state of all events on if they are limited or not.
    overriding function Dump_Event_States (Self : in out Instance) return Command_Execution_Status.E;

--- a/src/components/event_limiter/test/component-event_limiter-implementation-tester.ads
+++ b/src/components/event_limiter/test/component-event_limiter-implementation-tester.ads
@@ -162,7 +162,7 @@ package Component.Event_Limiter.Implementation.Tester is
    -- Data product handler primitives:
    -----------------------------------------------
    -- Description:
-   --    Data products for the pid controller component.
+   --    Data products for the event limiter component.
    -- The number of events that were limited since the last tick.
    overriding procedure Limited_Events_Since_Tick (Self : in out Instance; Arg : in Packed_U16.T);
    -- The total number of events that have been limited so far

--- a/src/components/event_limiter/test/event_limiter.tests.yaml
+++ b/src/components/event_limiter/test/event_limiter.tests.yaml
@@ -17,4 +17,6 @@ tests:
     description: This unit test exercises updating the persistence and ensures it was set correctly.
   - name: Test_Invalid_Command
     description: This unit test exercises that an invalid command throws the appropriate event.
+  - name: Test_Event_Limited_Array_Boundary
+    description: This unit test verifies that when more event IDs hit their limit than can fit in the Event_Id_Limited_Array, the component handles the overflow gracefully without writing past the array bounds.
 

--- a/src/components/event_limiter/test/event_limiter_tests-implementation.adb
+++ b/src/components/event_limiter/test/event_limiter_tests-implementation.adb
@@ -967,6 +967,8 @@ package body Event_Limiter_Tests.Implementation is
       Natural_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get_Count, 1);
       Command_Response_Assert.Eq (T.Command_Response_T_Recv_Sync_History.Get (1), (Source_Id => 0, Registration_Id => 0, Command_Id => T.Commands.Get_Set_Event_Limit_Persistence_Id, Status => Success));
       Natural_Assert.Eq (T.Set_New_Persistence_History.Get_Count, 1);
+      -- Verify the persistence value in the event matches the commanded value
+      Natural_Assert.Eq (Natural (T.Set_New_Persistence_History.Get (1).Persistence), 4);
 
       -- Test that the persistence took effect
       T.Event_Forward_T_Recv_Sync_History.Clear;
@@ -1012,5 +1014,48 @@ package body Event_Limiter_Tests.Implementation is
       Natural_Assert.Eq (T.Invalid_Command_Received_History.Get_Count, 1);
       Invalid_Command_Info_Assert.Eq (T.Invalid_Command_Received_History.Get (1), (Id => T.Commands.Get_Disable_Event_Limit_Range_Id, Errant_Field_Number => Interfaces.Unsigned_32'Last, Errant_Field => [0, 0, 0, 0, 0, 0, 0, 0]));
    end Test_Invalid_Command;
+
+   overriding procedure Test_Event_Limited_Array_Boundary (Self : in out Instance) is
+      T : Component.Event_Limiter.Implementation.Tester.Instance_Access renames Self.Tester;
+      Input_Tick : constant Tick.T := ((0, 0), 0);
+      Incoming_Event : Event.T;
+   begin
+      Put_Line ("");
+      Put_Line ("--------------------------------------------------");
+      Put_Line ("Testing Event_Id_Limited_Array boundary overflow:");
+      Put_Line ("--------------------------------------------------");
+
+      -- Initialize with 11 event IDs (0..10), which exceeds the 10-slot
+      -- Event_Id_Limited_Array. Persistence of 3 means the 4th occurrence
+      -- of each event ID hits the limit.
+      Self.Tester.Component_Instance.Init (Event_Id_Start => 0, Event_Id_Stop => 10, Event_Disable_List => [1 .. 0 => 0], Event_Limit_Persistence => 3);
+      T.Data_Product_T_Recv_Sync_History.Clear;
+      T.Event_T_Recv_Sync_History.Clear;
+      T.Events_Limited_Since_Last_Tick_History.Clear;
+      T.Event_Forward_T_Recv_Sync_History.Clear;
+
+      -- Send 4 events for each of the 11 IDs so all hit their limit:
+      for Id in Event_Types.Event_Id range 0 .. 10 loop
+         Incoming_Event.Header.Id := Id;
+         for Count in 1 .. 4 loop
+            T.Event_T_Send (Incoming_Event);
+         end loop;
+      end loop;
+
+      -- Clear history right before tick to get a clean count:
+      T.Events_Limited_Since_Last_Tick_History.Clear;
+      T.Event_T_Recv_Sync_History.Clear;
+
+      -- Now tick. This iterates all 11 IDs, finds all at Event_Max_Limit,
+      -- and tries to add each to the 10-slot array.
+      T.Tick_T_Send (Input_Tick);
+
+      -- Verify the event was sent with the limited count.
+      Natural_Assert.Eq (T.Events_Limited_Since_Last_Tick_History.Get_Count, 1);
+      Natural_Assert.Eq (Natural (T.Events_Limited_Since_Last_Tick_History.Get (1).Num_Event_Ids), 10);
+
+      -- Verify all 11 events were actually limited (total count):
+      Natural_Assert.Eq (Natural (T.Events_Limited_Since_Last_Tick_History.Get (1).Num_Events_Limited), 11);
+   end Test_Event_Limited_Array_Boundary;
 
 end Event_Limiter_Tests.Implementation;

--- a/src/components/event_limiter/test/event_limiter_tests-implementation.ads
+++ b/src/components/event_limiter/test/event_limiter_tests-implementation.ads
@@ -30,6 +30,9 @@ private
    overriding procedure Test_Persistence_Change (Self : in out Instance);
    -- This unit test exercises that an invalid command throws the appropriate event.
    overriding procedure Test_Invalid_Command (Self : in out Instance);
+   -- This unit test verifies that when more event IDs hit their limit than can fit in the Event_Id_Limited_Array,
+   -- the component handles the overflow gracefully without writing past the array bounds.
+   overriding procedure Test_Event_Limited_Array_Boundary (Self : in out Instance);
 
    -- Test data and state:
    type Instance is new Event_Limiter_Tests.Base_Instance with record

--- a/src/components/event_limiter/types/event_enable_state_type.record.yaml
+++ b/src/components/event_limiter/types/event_enable_state_type.record.yaml
@@ -1,5 +1,5 @@
 ---
-description: This record contains the definition for a two event ID type for ranges in the event limiter commands as well as an issue packet type for issuing packets
+description: This record contains the enable/disable state of the event limiter component master switch.
 fields:
   - name: Component_Enable_State
     description: Flag to indicate if the component is enabled or disabled at a overriding level

--- a/src/components/event_limiter/types/event_limiter_persistence_type.record.yaml
+++ b/src/components/event_limiter/types/event_limiter_persistence_type.record.yaml
@@ -1,7 +1,7 @@
 ---
 description: This record contains the definition for a packed persistence type
 fields:
-  - name: persistence
+  - name: Persistence
     description: The persistence that is used when limiting events.
-    type: Two_Counter_Entry.persistence_type
+    type: Two_Counter_Entry.Persistence_Type
     format: U8

--- a/src/components/event_limiter/types/event_single_state_cmd_type.record.yaml
+++ b/src/components/event_limiter/types/event_single_state_cmd_type.record.yaml
@@ -1,8 +1,8 @@
 ---
-description: This record contains the definition for a two event ID type for ranges in the event limiter commands as well as an issue packet type for issuing packets
+description: This record contains the definition for a single event ID and an issue packet flag for the event limiter enable/disable commands.
 fields:
   - name: Event_To_Update
-    description: The starting event ID to begin the range
+    description: The event ID to update
     type: Event_Id.T
   - name: Issue_State_Packet
     description: Flag to indicate if we dump the states after the change is complete


### PR DESCRIPTION
Squashed fixes from code review PR #62.

**Changes:**
- **Critical:** Fix off-by-one in Num_Event_Ids array fill guard (`<=` → `<`)
- **New test:** Unit test proving the boundary overflow (12 IDs exceeding 10-slot Event_Id_Limited_Array)
- **High:** Fix Assert placed after the call it guards in Init
- **Medium:** Fix misleading comments (Init, Tick, Persistence range)
- **Medium:** Add test for out-of-range event IDs
- **Low:** Fix description errors in YAML types, spec comments, assert messages
- **Low:** Add test for persistence value verification via event
- **YAML:** Fix capitalization in event_limiter_persistence_type.record.yaml (`persistence` → `Persistence`, `persistence_type` → `Persistence_Type`)

All style checks pass (`redo style_all`).

See: #62