### PR TITLE
FIXES - Code review: event_filter

### DIFF
--- a/src/components/event_filter/event_filter.component.yaml
+++ b/src/components/event_filter/event_filter.component.yaml
@@ -8,7 +8,7 @@ execution: passive
 with:
   - Event_Types
 init:
-  description:
+  description: Initializes the event filter with the given ID range and optionally a list of event IDs to filter by default.
   parameters:
     - name: Event_Id_Start_Range
       type: Event_Types.Event_Id

--- a/src/components/event_filter/event_filter.events.yaml
+++ b/src/components/event_filter/event_filter.events.yaml
@@ -32,4 +32,4 @@ events:
     description: This event indicates that changing the state for the range to disabled, failed due to an invalid id.
     param_type: Event_Filter_Id_Range.T
   - name: Dump_Event_States_Received
-    description: Event that indicates the process of building the packet that stores the event states has started and will send the packet once we go through a decrement cycle.
+    description: Event that indicates a request to dump the event filter state packet has been received. The packet will be sent on the next tick.

--- a/src/components/event_filter/event_filter_entry/event_filter_entry.adb
+++ b/src/components/event_filter/event_filter_entry/event_filter_entry.adb
@@ -102,6 +102,7 @@ package body Event_Filter_Entry is
    begin
       -- Check the component state. If its disabled then skip the logic altogether and just pass out that we are not filtered
       if Self.Global_Enable_State = Global_Filter_State.Disabled then
+         Self.Num_Events_Unfiltered := @ + 1;
          return Unfiltered;
       end if;
 

--- a/src/components/event_filter/event_filter_entry/event_filter_entry.ads
+++ b/src/components/event_filter/event_filter_entry/event_filter_entry.ads
@@ -1,5 +1,7 @@
--- This is a generic, unprotected statistics data structure.
--- The user can instantiate this class with any type that they choose.
+-- This package provides a bit-packed event filter data structure.
+-- Each event ID within a configured range has an associated filter state
+-- (Filtered/Unfiltered) stored as a single bit. The structure also tracks
+-- filtered/unfiltered event counts and a global enable/disable switch.
 with Basic_Types;
 with Event_Types;
 with Event_Filter_Entry_Enums;
@@ -46,7 +48,8 @@ package Event_Filter_Entry is
    function Get_Event_Unfiltered_Count (Self : in Instance) return Interfaces.Unsigned_32;
    -- Function to fetch the event range. This helps keep the component in sync with the package
    function Get_Event_Start_Stop_Range (Self : in Instance; Event_Stop_Id : out Event_Id) return Event_Id;
-   -- Function to get the pointer for the array. This is so that we can quickly copy the whole thing into the state packet
+   -- WARNING: Returns a direct pointer to internal state. Callers MUST treat as read-only.
+   -- Used for efficient serialization into state packets by the owning component.
    function Get_Entry_Array (Self : in Instance) return Basic_Types.Byte_Array_Access;
 
 private

--- a/src/components/event_filter/event_filter_entry/test/event_filter_entry_tests-implementation.adb
+++ b/src/components/event_filter/event_filter_entry/test/event_filter_entry_tests-implementation.adb
@@ -103,10 +103,11 @@ package body Event_Filter_Entry_Tests.Implementation is
          Start_List : constant Event_Id_List := [2, 5];
       begin
          Event_Filter.Init (Event_Id_Start => 7, Event_Id_Stop => 2, Event_Filter_List => Start_List);
+         -- If we reach here, the expected exception was not raised
+         Assert (False, "Expected assertion failure for invalid Event ID range, but Init succeeded");
       exception
-         -- Expecting the assert to be thrown here:
          when others =>
-            Assert (True, "Invalid Event ID Range assert failed!");
+            null; -- Expected: assertion fired for invalid range
       end Invalid_Init_Range;
 
    begin
@@ -625,6 +626,21 @@ package body Event_Filter_Entry_Tests.Implementation is
 
       State_Filter_Status := Event_Filter.Filter_Event (7);
       Event_Filter_Status_Assert.Eq (State_Filter_Status, Filtered);
+
+      -- Test counter behavior when globally disabled (Issue 4.4)
+      -- The unfiltered counter should still increment when globally disabled
+      declare
+         Unfiltered_Before : constant Unsigned_32 := Event_Filter.Get_Event_Unfiltered_Count;
+      begin
+         Event_Filter.Set_Global_Enable_State (Global_Filter_State.Disabled);
+         State_Filter_Status := Event_Filter.Filter_Event (4); -- would be filtered if enabled
+         Event_Filter_Status_Assert.Eq (State_Filter_Status, Unfiltered);
+         State_Filter_Status := Event_Filter.Filter_Event (5); -- unfiltered either way
+         Event_Filter_Status_Assert.Eq (State_Filter_Status, Unfiltered);
+         -- Both events should have incremented the unfiltered counter
+         Unsigned_32_Assert.Eq (Event_Filter.Get_Event_Unfiltered_Count, Unfiltered_Before + 2);
+         Event_Filter.Set_Global_Enable_State (Global_Filter_State.Enabled);
+      end;
 
       Event_Filter.Destroy;
       pragma Unreferenced (Event_Filter);


### PR DESCRIPTION
Cherry-picked fix commits from PR #60 and PR #61 with conflicts resolved.

**Commits:**
1. Fix High: Invalid_Init_Range test always passes
2. Fix Medium: Filter_Event does not count when globally disabled
3. Fix Medium: Get_Entry_Array exposes mutable internal state
4. Fix Low: Misleading package-level comment
5. Fix Low: No test for Filter_Event counters when globally disabled
6. Fix Low: Add init section description to component YAML
7. Fix Low: Correct Dump_Event_States_Received description