### PR TITLE
perf: fast tab completion via persistent DB + text cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN cd /root \
 # Install redo
 FROM base AS install_redo
 ARG TARGETARCH
-ENV REDO_VERSION="v0.2.2"
+ENV REDO_VERSION="v0.2.3"
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq wget \
     && mkdir -p /root/redo \
     && cd /root/redo \

--- a/env/activate
+++ b/env/activate
@@ -222,3 +222,18 @@ export -p > /tmp/.adamant_env_snapshot
 
 # Adding redo tab completion feature to shell
 . $ADAMANT_DIR/env/redo_completion.sh
+
+# Pre-warm the persistent target cache in the background if it does not
+# already exist. We use the breadcrumb file written by 
+# redo/database/persistent_target_cache.py's get_cache_dir() to find
+# the correct cache path without duplicating the hash logic in shell.
+_redo_breadcrumb="/tmp/redo-$(id -u)/cache_dir"
+_redo_need_warmup=true
+if [ -f "$_redo_breadcrumb" ]; then
+    _redo_cache_dir=$(cat "$_redo_breadcrumb")
+    [ -f "$_redo_cache_dir/redo_target.db" ] && _redo_need_warmup=false
+fi
+if [ "$_redo_need_warmup" = true ]; then
+    (python3 -m database.persistent_target_cache >/dev/null 2>&1 &)
+fi
+unset _redo_breadcrumb _redo_cache_dir _redo_need_warmup

--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -3,19 +3,6 @@
 # The function that provides bash completions for the redo command.
 # To see debug messages, set DBG=true.
 __redo_completion () {
-    local underscore=$_ # must be very first command
-    local special_arg=____redo_completion_special_arg
-    local first_run=false
-    [ "$underscore" != "$special_arg" ] && first_run=true
-
-
-    # $_ is set to the argument of the last executed command
-    # so on the first run, it will depend on what the user just ran
-    # the second run onwards, it will be set to $special_arg
-    # this function runs once after every tab completion,
-    # so we can use this to detect whether this is the user's first tab press
-
-
     dbg () {
         local prevstatus=$?
         [ "$DBG" = true ] &&  echo - "$@"
@@ -23,7 +10,7 @@ __redo_completion () {
     }
 
     dbg
-    dbg "> start: first_run=$first_run this_word=$this_word"
+    dbg "> start: this_word=$this_word"
 
 
     ##########################################
@@ -50,46 +37,42 @@ what" | grep -v "^$"
         redo_cmd_parsed "$path/what_predefined"
     }
 
-    # main cache: stores output of previous runs of `redo what`
-    words_cache_ok () {
+    # Fast text cache read for tab completion
+    # Reads the breadcrumb written by Python's get_cache_dir() to find
+    # the cache directory, then reads the per-directory text cache file.
+    # Returns the cached targets on stdout, or fails (return 1) on miss.
+    text_cache_read () {
         local path=$1
-        [ -f "$path"/build/redo/what_cache.txt ] || return 1
-        [ -n "$(cat "$path"/build/redo/what_cache.txt)" ] || return 1
-        # todo: check for file integrity, timestamp, etc?
+        local abs_dir
+        # Resolve to absolute path without subshells when possible
+        if [ "$path" = "." ]; then
+            abs_dir=$PWD
+        elif [[ "$path" == /* ]]; then
+            abs_dir="$path"
+        else
+            abs_dir=$(cd "$path" 2>/dev/null && pwd) || return 1
+        fi
+
+        local breadcrumb="/tmp/redo-$(id -u)/cache_dir"
+        local cache_dir
+        read -r cache_dir < "$breadcrumb" 2>/dev/null || return 1
+
+        # Encode directory path as filename: /foo/bar → _foo_bar
+        # Must match Python's save_text_cache() encoding.
+        local dir_key="${abs_dir//\//_}"
+        local text_file="${cache_dir}/what/${dir_key}.txt"
+
+        # Text cache must exist and be non-empty
+        [ -s "$text_file" ] || return 1
+
+        # Invalidate if directory has changed (files added/removed)
+        local text_mtime dir_mtime
+        text_mtime=$(stat -c %Y "$text_file" 2>/dev/null) || return 1
+        dir_mtime=$(stat -c %Y "$abs_dir" 2>/dev/null) || return 1
+        [ "$text_mtime" -ge "$dir_mtime" ] || return 1
+
+        cat "$text_file"
         return 0
-    }
-
-    words_cache_save () {
-        local path=$1
-        local res status
-        res="$(what_parsed "$path")"
-        status=$?
-        echo "$res"
-        [ "$status" = 0 ] || return 2
-        mkdir -p "$path"/build/redo && echo "$res" > "$path"/build/redo/what_cache.txt
-        [ "$?" = 0 ] || return 1
-        return 0
-    }
-
-    # short lived cache of a directories in which we've run `redo what`
-    # i.e. can we assume that the cache in this directory is completely up to date?
-    dir_first_visit () {
-        local path=$1 filename=~/.cache/redo/what_cache_dirs.txt
-        [ -f "$filename" ] || return 0
-
-        cat "$filename" | grep "^$path\$" >/dev/null && return 1
-        return 0
-    }
-
-    dir_cache_save () {
-        local path=$1
-        mkdir -p ~/.cache/redo/ 2>/dev/null && echo "$path" >> ~/.cache/redo/what_cache_dirs.txt
-    }
-
-    # doesn't take a path, since dir cache is always relative to ./
-    dir_cache_clean () {
-        local filename=~/.cache/redo/what_cache_dirs.txt
-        [ -f "$filename" ] && rm "$filename"
     }
 
     # shorter-lived cache to avoid having to recurse every new dir completion
@@ -129,7 +112,7 @@ what" | grep -v "^$"
         if echo "$string" | grep '/' >/dev/null; then
             # lmao, the sed command is replace 1 or more slashes with just 1 slash
             LEAD_DIR=$(echo "$string" | sed 's/\/\/*/\//' | cut -d '/' -f 1)
-            if [ "$LEAD_DIR" != build ] && [ -d "$basepath/$LEAD_DIR" ]; then
+            if [ -d "$basepath/$LEAD_DIR" ]; then
                 all_ifs=true
                 REST=$(echo "$string" | sed 's/\/\/*/\//' | cut -d '/' -f 2-)
             fi
@@ -145,7 +128,7 @@ what" | grep -v "^$"
     # these assume lots of global state
 
     prepend_path () {
-        if [ $path != . ] && [ -n "$RES" ]; then
+        if [ "$path" != . ] && [ -n "$RES" ]; then
             RES=$(echo "$RES" | prepend "$path/")
         fi
     }
@@ -155,8 +138,6 @@ what" | grep -v "^$"
         local full_arg
         if [ "$path" = . ]; then
             full_arg=$arg
-        # elif [ -z "$arg" ]; then
-            # full_arg=$path
         else
             full_arg=$path/$arg
         fi
@@ -165,18 +146,14 @@ what" | grep -v "^$"
 
         # stupid way of appending lines to variable
         RES=$(echo "$RES
-$(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
+$(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
     }
 
     synchronous_work () {
-        compgen_arg=$(words_cache_save "$path")
+        compgen_arg=$(what_parsed "$path")
         RES=$(compgen -W "$compgen_arg" "$arg")
         prepend_path
         append_compgen_dirs
-    }
-
-    async_work () {
-        words_cache_save "$path" >/dev/null
     }
 
     should_recurse () {
@@ -217,30 +194,57 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
         # return value -- must reset at start of function
         RES=
 
-        # clean up $path / $arg -- replace instances of ./ with nothing
-        path=$(echo "$path" | sed 's/\b\.\///')
-        arg=$(echo "$arg" | sed 's/\b\.\///')
+        # clean up $path / $arg, strip leading ./ prefix
+        [[ "$path" == ./* ]] && path="${path#./}"
+        [ -z "$path" ] && path="."
+        [[ "$arg" == ./* ]] && arg="${arg#./}"
         [ "$arg" = . ] && arg=./ # just bc the user must have typed it in
 
         dbg "> enter helper: path=($path) arg=($arg)"
 
+        # Fast path: try text cache first (fast) before spawning any
+        # Python subprocess (slower). A valid text cache proves this is a
+        # redo directory, so we can skip what_predef_parsed entirely.
+        local compgen_arg
+        if compgen_arg=$(text_cache_read "$path" 2>/dev/null); then
+            dbg '> text cache hit (fast path)'
+
+            RES=$(compgen -W "$compgen_arg" "$arg")
+
+            if [ -n "$RES" ]; then
+                dbg '> matched'
+                prepend_path
+                append_compgen_dirs
+                return 0
+            fi
+
+            dbg '> text cache hit but no match for arg'
+
+            # no match, so check for a directory prefix
+            if should_recurse; then
+                do_recurse
+                return $?
+            fi
+
+            # fall through to dir completion
+            RES=
+            append_compgen_dirs
+            return 0
+        fi
+
+        dbg '> text cache miss, trying slow path'
+
+        # Slow path: no text cache. Check if this is a redo directory
+        # by calling what_predef_parsed (spawns redo subprocess, tens of ms).
         if what_predef_parsed "$path" >/dev/null; then
             # path only gets edited when we recurse, so this is safe
             save_last_confirmed_dir "$path"
         else
-            # TODO: make completion work inside of /build directory
-            # for now just dip
             dbg '> redo what unavailable'
-            if pwd | grep '/build$' >/dev/null; then
-                dbg '> stuck in build/ so dip'
-                return 0
-            fi
 
-            # `redo what` isn't even available
-            # so just complete dirs
+            # redo what is not available here, so just complete dirs
             append_compgen_dirs
             dbg new res just dropped "RES ($RES)"
-            # return 1
 
             if should_recurse; then
                 dbg '> yet recurse'
@@ -250,59 +254,17 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
             return 0
         fi
 
-
-        # locals
-        local compgen_arg first_run=false
-        if dir_first_visit "$path"; then
-            first_run=true
-            dir_cache_save "$path"
-        fi
-
-        # overview:
-        # if typed `redo <tab>` or `redo path/<tab>`, run `redo what` synchronously
-        # check word cache (fallback to `redo what_predefined`)
-        # -> if match, use the result and update caches in background
-        # if no matches yet, check for redo's path syntax
-        # -> if match, recurse using subdirectory
-        # if still no matches, match against directory names
-        # if *still* no matches, and cache is outdated, synchronously run `redo what`
-        # return regardless of matches
-
-
-        # I assume that if someone types `redo <tab>`,
-        # they probably want an up-to-date list of commands
-        # but if someone types `redo b<tab>` for example,
-        # they probably intended to autocomplete build/
-        # which is likely still available, and useful to provide instantly
-
-        # if typed `redo <tab>` and cache is outdated, bypass cache
-        if [ "$first_run" = true ] && [ -z "$arg" ]; then
-            synchronous_work
-            append_compgen_dirs
-            return 0
-        fi
-
-
-        if words_cache_ok "$path"; then
-            compgen_arg=$(cat "$path"/build/redo/what_cache.txt)
-            dbg '> cache ok'
-        else
-            # fallback to `redo what_predefined`
-            compgen_arg=$(what_predef_parsed "$path")
-            dbg '> cache fallback to what_predef'
-        fi
+        # No text cache — call redo what (also populates text cache)
+        compgen_arg=$(what_parsed "$path")
+        dbg '> called redo what (slow path)'
 
         # generate completions
         RES=$(compgen -W "$compgen_arg" "$arg")
 
         if [ -n "$RES" ]; then
-
-            dbg '> used cache'
-
+            dbg '> matched'
             prepend_path
             append_compgen_dirs
-            (async_work &)
-
             return 0
         fi
 
@@ -322,20 +284,13 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
         append_compgen_dirs
 
         if [ -n "$RES" ]; then
-            # no need to prepend_path
-            (async_work &)
             return 0
         fi
 
         # now there's really nothing to match
-        # so do synchronous anyway, but only on first run
-        # this is useful for i.e. autocompleting build/ in a directory for the first time after making a .component.yaml file
-        if [ "$first_run" = true ]; then
-            dbg '> synchronous time'
-            synchronous_work
-            return 0
-        fi
-        dbg '> no matches at all'
+        # so do synchronous completion as a final fallback
+        dbg '> synchronous time'
+        synchronous_work
         return 0
     }
 
@@ -369,13 +324,6 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
     # end definitions, start running stuff
     ######################################
 
-    # helps us figure out whether re-running `redo what` is a waste
-    # if first_run=true then the user might have run commands
-    # which might change the output of `redo what`
-    if [ $first_run = true ]; then
-        dir_cache_clean
-    fi
-
     local cmdname=$1 this_word=$2 prev_word=$3
     local starting_dir=.
 
@@ -387,10 +335,57 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
         this_word=$(echo "$this_word" | sed "s#~#$HOME#")
     fi
 
+    # Handle absolute paths: split into a starting directory that has
+    # a text cache (redo project dir) and the remainder as this_word.
+    # Walk up from the deepest directory until we find a text cache,
+    # so that "~/proj/src/comp/build/" becomes starting_dir=".../comp"
+    # this_word="build/" and the existing compgen matches build/* targets.
+    if [[ "$this_word" == /* ]]; then
+        local abs_path="$this_word"
+        local found_cache=false
+
+        # Strip trailing slash for splitting, remember if it was there
+        local trailing_slash=false
+        [[ "$abs_path" == */ ]] && trailing_slash=true
+        abs_path="${abs_path%/}"
+
+        # Walk up directories to find one with a text cache
+        local try_dir="$abs_path"
+        while [ -n "$try_dir" ] && [ "$try_dir" != "/" ]; do
+            if text_cache_read "$try_dir" >/dev/null 2>&1; then
+                starting_dir="$try_dir"
+                # Remainder is everything after starting_dir
+                local remainder="${abs_path#$try_dir}"
+                remainder="${remainder#/}"
+                if [ "$trailing_slash" = true ] && [ -n "$remainder" ]; then
+                    remainder="$remainder/"
+                elif [ "$trailing_slash" = true ]; then
+                    remainder=""
+                fi
+                this_word="$remainder"
+                found_cache=true
+                break
+            fi
+            try_dir="${try_dir%/*}"
+        done
+
+        # No cache found, fall back to simple split at last /
+        if [ "$found_cache" = false ]; then
+            if [[ "${this_word}" == */ ]]; then
+                starting_dir="${this_word%/}"
+                this_word=""
+            else
+                starting_dir="${this_word%/*}"
+                this_word="${this_word##*/}"
+            fi
+            [ -z "$starting_dir" ] && starting_dir="/"
+        fi
+    fi
+
     # call helper function
 
     # helper function sets the RES variable
-    if [ "$first_run" = false ] && try_cached_dir; then
+    if try_cached_dir; then
         # this saves a few recursions
         # see recursion in helper function for when this gets cached
         dbg "> insta-recurse"
@@ -420,12 +415,10 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
         unset oldifs
     fi
 
-    unset -f redo_cmd_parsed what_parsed what_predef_parsed words_cache_ok words_cache_save dir_first_visit dir_cache_save dir_cache_clean save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir append_compgen_dirs synchronous_work async_work prepend_path redo_completion_helper try_cached_dir
+    unset -f redo_cmd_parsed what_parsed what_predef_parsed text_cache_read save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir append_compgen_dirs synchronous_work prepend_path redo_completion_helper try_cached_dir
 
-    # must be very last command, see top
-    echo $special_arg > /dev/null
 }
 
 # the reason we can't use `complete -o dirnames` is that
-# we need to exclude ./build (and want to exclude hidden dirs)
+# we want to exclude hidden dirs
 complete -o nospace -o nosort -F __redo_completion redo

--- a/redo/database/_setup.py
+++ b/redo/database/_setup.py
@@ -428,6 +428,21 @@ def _delayed_cleanup(redo_1, redo_2, redo_3):
     can detect if a process is still using the temp directory by the presence of
     *.running files in the directory.
     """
+    # Save the target database to a persistent location before cleanup.
+    # This allows 'redo what' to read it directly without rebuilding.
+    # Skip when 'redo what' is the caller — it sets _REDO_WHAT_ACTIVE
+    # and handles its own per-directory cache updates via
+    # update_persistent_db_targets(), so saving the full session DB here
+    # would overwrite complete data with single-directory data.
+    if not os.environ.get("_REDO_WHAT_ACTIVE"):
+        try:
+            from database.persistent_target_cache import save_persistent_db
+            session_dir = _get_session_dir()
+            session_db = os.path.join(session_dir, "db", "redo_target.db")
+            save_persistent_db(session_db)
+        except Exception:
+            pass  # Don't let cache save failures break cleanup
+
     if not os.environ.get("ADAMANT_DISABLE_SESSION_CLEANUP"):
         # First remove our .running file to signify to other processes that we are no
         # longer using the temporary directory, and from our perspective it can be cleaned.

--- a/redo/database/_setup.py
+++ b/redo/database/_setup.py
@@ -159,6 +159,21 @@ def _get_user_build_roots():
     return _get_path_from_env("BUILD_ROOTS")
 
 
+def _compute_build_roots(cwd):
+    """
+    Compute the build roots for the current environment.
+
+    If the user provided BUILD_PATH, no roots are needed (returns empty).
+    Otherwise uses BUILD_ROOTS (or git root fallback) plus EXTRA_BUILD_ROOTS.
+    """
+    user_build_path = _get_user_build_path()
+    if user_build_path:
+        roots = []
+    else:
+        roots = _get_build_roots(cwd)
+    return _sanitize_path(roots + _get_extra_build_roots())
+
+
 def _get_user_remove_build_path():
     """
     Get the remove build path, as provided by the
@@ -310,15 +325,10 @@ def _setup(redo_1, redo_2, redo_3, sandbox=False):
     # we don't need to search for a path at all, which means
     # we don't need a build root.
     user_build_path = _get_user_build_path()
-    roots = []
     additional_path = []
     run_dir = redo_arg.get_src_dir(redo_2)
     if user_build_path:
         additional_path = user_build_path
-    # A build path was not given, instead should construct the path
-    # from the build roots.
-    else:
-        roots = _get_build_roots(run_dir)
 
     # The total additional path is sum of the user build path, the extra
     # build path and the source directory of the current redo target.
@@ -326,10 +336,8 @@ def _setup(redo_1, redo_2, redo_3, sandbox=False):
         additional_path + _get_extra_build_path() + [run_dir]
     )
 
-    # The total build roots are the sum of the user build roots (or the
-    # assumed build root if that was not available) and the extra build
-    # roots:
-    roots = _sanitize_path(roots + _get_extra_build_roots())
+    # Compute build roots using the shared helper.
+    roots = _compute_build_roots(run_dir)
 
     # If the build target is defined in the redo target ie. something like:
     #   redo build/obj/Linux/main.elf

--- a/redo/database/database.py
+++ b/redo/database/database.py
@@ -257,6 +257,16 @@ class database(object):
             values.append(self.fetch(key))
         return values
 
+    def items(self):
+        """Yield (key, deserialized value) pairs from the database."""
+        for key, raw_value in self.db:
+            yield key, pickle.loads(raw_value)
+
+    def __iter__(self):
+        """Iterate over keys in the database."""
+        for key, _raw_value in self.db:
+            yield key
+
     def does_key_exist(self, key):
         """
         Return True is a key exists in the database, otherwise

--- a/redo/database/persistent_target_cache.py
+++ b/redo/database/persistent_target_cache.py
@@ -122,6 +122,79 @@ def save_persistent_db(session_db_path):
         pass
 
 
+def generate_text_caches(persistent_db_path=None):
+    """
+    Generate text cache files for every directory in the persistent DB.
+
+    This gives shell completion instant reads without needing to spawn a
+    Python subprocess on the first TAB press for each directory.  Called
+    at the end of build_full_target_cache() so that activate pre-warms
+    both the persistent DB and the text caches.
+    """
+    from rules.build_what import save_text_cache, _uniquify_preserve_order
+    from rules.build_what_predefined import get_predefined_targets
+
+    if persistent_db_path is None:
+        persistent_db_path = get_persistent_db_path()
+    if not os.path.isfile(persistent_db_path):
+        return
+
+    predefined = get_predefined_targets()
+
+    try:
+        # Collect all directories and their targets from the DB.
+        # Intermediate dirs like /project/src/components/ won't have
+        # DB entries but still need text caches with predefined targets
+        # so that tab completion is instant.
+        all_dirs = {}  # directory → target list
+        with database(persistent_db_path, DATABASE_MODE.READ_ONLY) as db:
+            for directory, targets in db.items():
+                try:
+                    all_dirs[directory] = list(targets)
+                except Exception:
+                    all_dirs[directory] = []
+
+        # Determine build roots, the top-level directories where we
+        # stop generating ancestor text caches.
+        from database.setup import get_build_roots
+        build_roots = set(os.path.abspath(r) for r in get_build_roots())
+
+        # Add ancestor directories (stop at build roots).
+        # For each leaf directory in the DB, walk up the tree and
+        # create text caches for intermediate dirs (src/, src/components/,
+        # etc.) that have no DB entries.  Skip this when build roots are
+        # unknown, since the walk would have no stopping point.
+        if build_roots:
+            ancestor_dirs = set()
+            for directory in list(all_dirs):
+                if directory in build_roots:
+                    continue
+                parent = os.path.dirname(directory)
+                while parent and parent != directory:
+                    if parent in all_dirs or parent in ancestor_dirs:
+                        break
+                    ancestor_dirs.add(parent)
+                    if parent in build_roots:
+                        break
+                    directory = parent
+                    parent = os.path.dirname(parent)
+            for d in ancestor_dirs:
+                if d not in all_dirs:
+                    all_dirs[d] = []  # predefined targets only
+
+        # Write text cache for each directory
+        for directory, targets in all_dirs.items():
+            redo_targets = list(predefined)
+            if targets:
+                targets.sort()
+                for target in targets:
+                    redo_targets.append(os.path.relpath(target, directory))
+                redo_targets = _uniquify_preserve_order(redo_targets)
+            save_text_cache(directory, redo_targets)
+    except Exception:
+        pass
+
+
 def build_full_target_cache():
     """
     Build the full project target database and save it to the persistent
@@ -151,6 +224,9 @@ def build_full_target_cache():
         session_dir = _get_session_dir()
         session_db = os.path.join(session_dir, "db", "redo_target.db")
         save_persistent_db(session_db)
+        # Generate text caches for all directories so shell completion
+        # is instant from the very first TAB press.
+        generate_text_caches()
         # Clean up
         database.setup.cleanup(redo_1, redo_2, redo_3)
 

--- a/redo/database/persistent_target_cache.py
+++ b/redo/database/persistent_target_cache.py
@@ -1,0 +1,160 @@
+"""
+Persistent target database cache.
+
+After each build, the ephemeral redo_target.db is copied to a persistent
+location in /tmp so that 'redo what' can read it instantly without
+rebuilding. The cache is keyed by project root path.
+
+Can also be invoked directly to build the full target DB:
+    python3 -m database.persistent_target_cache
+"""
+import hashlib
+import os
+import os.path
+import shutil
+
+from database.database import database, DATABASE_MODE
+
+
+def _get_project_key():
+    """
+    Return a stable key identifying the current project environment.
+
+    Uses ADAMANT_CONFIGURATION_YAML env var (unique per project) so the
+    same cache is found regardless of which subdirectory you're in.
+    Raises if the env var is not set. The adamant environment must be
+    activated before using the persistent cache.
+    """
+    config_yaml = os.environ.get("ADAMANT_CONFIGURATION_YAML")
+    if not config_yaml:
+        raise EnvironmentError(
+            "ADAMANT_CONFIGURATION_YAML is not set. "
+            "The adamant environment must be activated (source env/activate) "
+            "before using the persistent target cache."
+        )
+    # Include TARGET in the key so different cross-compile targets
+    # (e.g. Linux vs an embedded target) get separate caches.
+    target = os.environ.get("TARGET", "")
+    return config_yaml + ":" + target
+
+
+def _get_cache_dir(project_key):
+    """Return /tmp/redo-<uid>/ cache directory for the given project."""
+    path_hash = hashlib.md5(project_key.encode()).hexdigest()[:12]
+    return os.path.join("/tmp", "redo-{uid}".format(uid=os.getuid()), path_hash)
+
+
+def get_cache_dir():
+    """
+    Return the cache directory for the current project.
+
+    Also writes a breadcrumb file at /tmp/redo-<uid>/cache_dir so
+    shell scripts can find the cache directory without recomputing
+    the hash themselves.
+    """
+    cache_dir = _get_cache_dir(_get_project_key())
+    # Write breadcrumb for shell consumption
+    try:
+        parent = os.path.dirname(cache_dir)
+        os.makedirs(parent, exist_ok=True)
+        breadcrumb = os.path.join(parent, "cache_dir")
+        tmp = breadcrumb + ".tmp"
+        with open(tmp, "w") as f:
+            f.write(cache_dir + "\n")
+        os.replace(tmp, breadcrumb)
+    except Exception:
+        pass
+    return cache_dir
+
+
+def get_persistent_db_path():
+    """
+    Return the path to the persistent target DB.
+    """
+    cache_dir = get_cache_dir()
+    return os.path.join(cache_dir, "redo_target.db")
+
+
+def update_persistent_db_targets(directory, targets):
+    """
+    Write a directory's targets directly into the persistent DB.
+    This is the preferred method when targets are already in memory.
+    """
+    import unqlite
+
+    persistent_path = get_persistent_db_path()
+
+    try:
+        os.makedirs(os.path.dirname(persistent_path), exist_ok=True)
+        mode = DATABASE_MODE.READ_WRITE if os.path.isfile(persistent_path) else DATABASE_MODE.CREATE
+        with database(persistent_path, mode) as dst:
+            dst.store(directory, targets)
+    except unqlite.UnQLiteError:
+        # DB is corrupt — remove so next build recreates clean.
+        try:
+            os.remove(persistent_path)
+        except OSError:
+            pass
+    except Exception:
+        # Lock contention, permissions, disk full, etc. — leave the
+        # existing DB alone; it may still be valid.
+        pass
+
+
+def save_persistent_db(session_db_path):
+    """
+    Copy the session's redo_target.db to the persistent location.
+    Called during build cleanup, before the session dir is destroyed.
+    """
+    if not os.path.isfile(session_db_path):
+        return
+
+    persistent_path = get_persistent_db_path()
+
+    try:
+        os.makedirs(os.path.dirname(persistent_path), exist_ok=True)
+        # Atomic copy: write to temp file then rename
+        tmp_path = persistent_path + ".tmp"
+        shutil.copy2(session_db_path, tmp_path)
+        os.replace(tmp_path, persistent_path)
+    except Exception:
+        # Don't let cache save failures break builds
+        pass
+
+
+def build_full_target_cache():
+    """
+    Build the full project target database and save it to the persistent
+    cache. This does a complete setup (loading all source/models) so it
+    could take a few seconds, but only needs to run once (e.g. from
+    env/activate).
+    """
+    import database.setup
+
+    _get_project_key()  # validates env is set
+
+    # Config yaml is at <project_root>/config/foo.yaml
+    config_yaml = os.environ["ADAMANT_CONFIGURATION_YAML"]
+    project_root = os.path.dirname(os.path.dirname(config_yaml))
+
+    # Run full setup from project root to populate the ephemeral target DB.
+    # These are intentionally fake redo paths used only to satisfy
+    # database.setup.setup(redo_1, redo_2, redo_3) path-shaped inputs.
+    redo_1 = os.path.join(project_root, "_cache_warmup")
+    redo_2 = os.path.join(project_root, "_cache_warmup.tmp")
+    redo_3 = os.path.join(project_root, "_cache_warmup.base")
+
+    did_setup = database.setup.setup(redo_1, redo_2, redo_3)
+    if did_setup:
+        # The setup populated the session target DB, save it
+        from database._setup import _get_session_dir
+        session_dir = _get_session_dir()
+        session_db = os.path.join(session_dir, "db", "redo_target.db")
+        save_persistent_db(session_db)
+        # Clean up
+        database.setup.cleanup(redo_1, redo_2, redo_3)
+
+
+# If called directly, this module will build the target cache from scratch.
+if __name__ == "__main__":
+    build_full_target_cache()

--- a/redo/database/setup.py
+++ b/redo/database/setup.py
@@ -20,6 +20,21 @@ def _do_setup(redo_1, redo_2, redo_3, sandbox=False):
     os.environ["ADAMANT_SETUP"] = "TRUE"
 
 
+def get_build_roots():
+    """
+    Return the list of build root directories for the current environment.
+
+    Prefers COMPUTED_BUILD_ROOTS (set after setup() runs). When that is
+    not available, computes roots using the same logic as setup().
+    """
+    computed = os.environ.get("COMPUTED_BUILD_ROOTS", "")
+    if computed:
+        return [p for p in computed.split(os.pathsep) if p.strip()]
+
+    from database._setup import _compute_build_roots
+    return _compute_build_roots(os.getcwd())
+
+
 def setup(redo_1, redo_2, redo_3):
     """
     This function sets up the databases for the build system if

--- a/redo/rules/build_what.py
+++ b/redo/rules/build_what.py
@@ -1,5 +1,6 @@
 from database.redo_target_database import redo_target_database
-from database.persistent_target_cache import get_persistent_db_path, save_persistent_db, update_persistent_db_targets
+from database.persistent_target_cache import get_persistent_db_path, get_cache_dir, update_persistent_db_targets
+from database.database import database, DATABASE_MODE
 import os.path
 import os
 import sys
@@ -11,6 +12,36 @@ from rules.build_what_predefined import get_predefined_targets
 def _uniquify_preserve_order(lst):
     """Remove duplicates while preserving first-occurrence order."""
     return sorted(set(lst), key=lambda x: lst.index(x))
+
+
+def _dir_to_key(directory):
+    """
+    Encode a directory path as a filename: /foo/bar → _foo_bar.
+
+    Must match the shell's encoding in redo_completion.sh:
+        dir_key="${abs_dir//\\//_}"
+    """
+    return directory.replace("/", "_")
+
+
+def save_text_cache(directory, lines):
+    """
+    Write redo what output lines to the text cache for a directory.
+
+    The text cache stores one target per line as plain text for instant
+    shell-side reads with no Python invocation.
+    """
+    try:
+        cache_dir = get_cache_dir()
+        dir_key = _dir_to_key(directory)
+        text_path = os.path.join(cache_dir, "what", dir_key + ".txt")
+        os.makedirs(os.path.dirname(text_path), exist_ok=True)
+        tmp_path = text_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.write("\n".join(lines) + "\n")
+        os.replace(tmp_path, text_path)
+    except Exception:
+        pass
 
 
 class build_what(build_rule_base):
@@ -40,10 +71,12 @@ class build_what(build_rule_base):
             try:
                 self._build_from_persistent(redo_1, directory, persistent_db)
                 return
+            except KeyError:
+                pass  # Directory not in DB, fall through to slow path
             except Exception:
-                pass  # DB corrupt or missing dir — fall through to slow path
+                pass  # DB corrupt, fall through to slow path
         # No persistent DB or DB corrupt.
-        # Setup for just this directory (fast ~300ms).
+        # Setup for just this directory (slower path).
         # Mark that we're running 'redo what' so _delayed_cleanup skips
         # overwriting the persistent DB with our partial single-directory data.
         environ["_REDO_WHAT_ACTIVE"] = "1"
@@ -57,29 +90,35 @@ class build_what(build_rule_base):
             except Exception:
                 pass
 
+    @staticmethod
+    def _output_targets(directory, redo_targets):
+        """Write targets to stderr and save text cache for shell completion."""
+        unique = _uniquify_preserve_order(redo_targets)
+        sys.stderr.write("redo " + "\nredo ".join(unique) + "\n")
+        try:
+            save_text_cache(directory, unique)
+        except Exception:
+            pass
+
     def _build_from_persistent(self, redo_1, directory, persistent_db):
         """Read targets from the persistent DB without running setup.
 
-        Raises RuntimeError if no targets found for the directory,
-        which signals the caller to fall back to the slow path.
+        Raises RuntimeError if the directory is not in the persistent DB
+        at all (KeyError), which signals the caller to fall back to the
+        slow path.  An empty target list is a valid cache hit. It means
+        the directory exists in the project but has no file-level build
+        targets (only predefined ones like all/clean/style).
         """
         redo_targets = get_predefined_targets()
-        from database.database import database, DATABASE_MODE
         with database(persistent_db, DATABASE_MODE.READ_ONLY) as db:
-            try:
-                targets = list(db.fetch(directory))
-            except Exception:
-                targets = []
-        if not targets:
-            raise RuntimeError("No targets in persistent DB for " + directory)
+            # Let KeyError propagate. That's a real cache miss.
+            targets = list(db.fetch(directory))
         if targets:
             targets.sort()
             for target in targets:
                 rel_target = os.path.relpath(target, directory)
                 redo_targets.append(rel_target)
-        sys.stderr.write(
-            "redo " + "\nredo ".join(_uniquify_preserve_order(redo_targets)) + "\n"
-        )
+        self._output_targets(directory, redo_targets)
 
     def _build(self, redo_1, redo_2, redo_3):
         # Define the special targets that exist everywhere...
@@ -97,9 +136,7 @@ class build_what(build_rule_base):
             for target in targets:
                 rel_target = os.path.relpath(target, directory)
                 redo_targets.append(rel_target)
-        sys.stderr.write(
-            "redo " + "\nredo ".join(_uniquify_preserve_order(redo_targets)) + "\n"
-        )
+        self._output_targets(directory, redo_targets)
 
     # No need to provide these for "redo what"
     # def input_file_regex(self): pass

--- a/redo/rules/build_what.py
+++ b/redo/rules/build_what.py
@@ -1,9 +1,16 @@
 from database.redo_target_database import redo_target_database
+from database.persistent_target_cache import get_persistent_db_path, save_persistent_db, update_persistent_db_targets
 import os.path
+import os
 import sys
 from base_classes.build_rule_base import build_rule_base
 from os import environ
 from rules.build_what_predefined import get_predefined_targets
+
+
+def _uniquify_preserve_order(lst):
+    """Remove duplicates while preserving first-occurrence order."""
+    return sorted(set(lst), key=lambda x: lst.index(x))
 
 
 class build_what(build_rule_base):
@@ -16,35 +23,82 @@ class build_what(build_rule_base):
     def build(self, redo_1, redo_2, redo_3):
         """
         We override build here for performance. With redo what there is no
-        need to load the source code and models from then entire project,
+        need to load the source code and models from the entire project,
         we just need to build path to include the directory pointed to by
         redo_1. So set that in the environment for speed, then call the
         normal implementation of build.
+
+        If a persistent target database exists from a previous build,
+        we use it directly, skipping the expensive _setup() entirely.
+        The persistent DB is updated automatically by each build.
         """
         directory = os.path.dirname(os.path.abspath(redo_1))
-        environ["BUILD_PATH"] = directory + os.pathsep + directory + os.sep + ".."
-        super(build_what, self).build(redo_1, redo_2, redo_3)
-
-    def _build(self, redo_1, redo_2, redo_3):
-        # https://stackoverflow.com/questions/1549509/remove-duplicates-in-a-list-while-keeping-its-order-python
-        def uniquify_preserve_order(lst):
-            return sorted(set(lst), key=lambda x: lst.index(x))
-
-        # Define the special targets that exist everywhere...
-        redo_targets = get_predefined_targets()
-        directory = os.path.dirname(redo_1)
-        with redo_target_database() as db:
+        persistent_db = get_persistent_db_path()
+        if persistent_db and os.path.isfile(persistent_db):
+            # Fast path: read from persistent DB, no setup needed.
+            # Data may be stale but that's fine — next build refreshes.
             try:
-                targets = db.get_targets_for_directory(directory)
-            except BaseException:
+                self._build_from_persistent(redo_1, directory, persistent_db)
+                return
+            except Exception:
+                pass  # DB corrupt or missing dir — fall through to slow path
+        # No persistent DB or DB corrupt.
+        # Setup for just this directory (fast ~300ms).
+        # Mark that we're running 'redo what' so _delayed_cleanup skips
+        # overwriting the persistent DB with our partial single-directory data.
+        environ["_REDO_WHAT_ACTIVE"] = "1"
+        environ["BUILD_PATH"] = directory + os.pathsep + directory + os.sep + ".."
+        self._last_targets = None
+        super(build_what, self).build(redo_1, redo_2, redo_3)
+        # Merge this directory's targets into persistent cache.
+        if self._last_targets is not None:
+            try:
+                update_persistent_db_targets(directory, self._last_targets)
+            except Exception:
+                pass
+
+    def _build_from_persistent(self, redo_1, directory, persistent_db):
+        """Read targets from the persistent DB without running setup.
+
+        Raises RuntimeError if no targets found for the directory,
+        which signals the caller to fall back to the slow path.
+        """
+        redo_targets = get_predefined_targets()
+        from database.database import database, DATABASE_MODE
+        with database(persistent_db, DATABASE_MODE.READ_ONLY) as db:
+            try:
+                targets = list(db.fetch(directory))
+            except Exception:
                 targets = []
+        if not targets:
+            raise RuntimeError("No targets in persistent DB for " + directory)
         if targets:
             targets.sort()
             for target in targets:
                 rel_target = os.path.relpath(target, directory)
                 redo_targets.append(rel_target)
         sys.stderr.write(
-            "redo " + "\nredo ".join(uniquify_preserve_order(redo_targets)) + "\n"
+            "redo " + "\nredo ".join(_uniquify_preserve_order(redo_targets)) + "\n"
+        )
+
+    def _build(self, redo_1, redo_2, redo_3):
+        # Define the special targets that exist everywhere...
+        redo_targets = get_predefined_targets()
+        directory = os.path.dirname(redo_1)
+        with redo_target_database() as db:
+            try:
+                targets = db.get_targets_for_directory(directory)
+            except Exception:
+                targets = []
+        # Save for persistent cache update in build()
+        self._last_targets = targets
+        if targets:
+            targets.sort()
+            for target in targets:
+                rel_target = os.path.relpath(target, directory)
+                redo_targets.append(rel_target)
+        sys.stderr.write(
+            "redo " + "\nredo ".join(_uniquify_preserve_order(redo_targets)) + "\n"
         )
 
     # No need to provide these for "redo what"

--- a/redo/test/persistent_cache/test_persistent_cache.sh
+++ b/redo/test/persistent_cache/test_persistent_cache.sh
@@ -1,0 +1,663 @@
+#!/bin/bash
+# Test suite for persistent target cache behavior.
+# Run inside an activated adamant environment:
+#   source env/activate && bash redo/test/persistent_cache/test_persistent_cache.sh
+
+set -e
+
+PASS=0
+FAIL=0
+TEST_DIR=""
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Timing helper: returns milliseconds
+time_ms() {
+    local start end
+    start=$(date +%s%N)
+    "$@" 2>/dev/null
+    end=$(date +%s%N)
+    echo $(( (end - start) / 1000000 ))
+}
+
+setup() {
+    # Pick a component directory for testing
+    TEST_DIR="${ADAMANT_DIR}/src/components/oscillator"
+    if [ ! -d "$TEST_DIR" ]; then
+        local example_dir
+        example_dir=$(dirname "$(dirname "$ADAMANT_CONFIGURATION_YAML")")
+        TEST_DIR="${example_dir}/src/components/oscillator"
+    fi
+    if [ ! -d "$TEST_DIR" ]; then
+        echo "ERROR: Cannot find oscillator component directory"
+        exit 1
+    fi
+
+    # Calibrate thresholds dynamically by measuring the uncached slow path.
+    # This makes tests portable across machines of different speeds.
+    cd "$TEST_DIR"
+    local db_path
+    db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())" 2>/dev/null)
+    # Remove caches to force cold path
+    [ -f "$db_path" ] && cp "$db_path" "${db_path}.calibrate"
+    rm -f "$db_path"
+    # Measure uncached redo what (cold path = full setup)
+    SLOW_BASELINE=$(time_ms redo what)
+    echo "Calibration: uncached redo what = ${SLOW_BASELINE}ms"
+    # Restore DB
+    [ -f "${db_path}.calibrate" ] && mv "${db_path}.calibrate" "$db_path"
+
+    # Thresholds derived from baseline:
+    # Fast = cached path, should be <25% of slow baseline
+    # Slow = uncached path, should be >40% of slow baseline
+    FAST_THRESHOLD=$(( SLOW_BASELINE / 4 ))
+    SLOW_THRESHOLD=$(( SLOW_BASELINE * 2 / 5 ))
+    # Floor: fast threshold at least 20ms (to avoid noise on very fast machines)
+    [ "$FAST_THRESHOLD" -lt 20 ] && FAST_THRESHOLD=20
+    echo "Thresholds: fast < ${FAST_THRESHOLD}ms, slow > ${SLOW_THRESHOLD}ms"
+
+    # Ensure persistent cache exists and warm up
+    python3 -m database.persistent_target_cache 2>/dev/null || true
+    cd "$TEST_DIR"
+    redo what 2>/dev/null
+}
+
+cleanup() {
+    cd "$TEST_DIR" 2>/dev/null || true
+    rm -f hi.do test_dummy.do dummy1.do dummy2.do 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+# -------------------------------------------------------
+echo "=== Persistent Target Cache Tests ==="
+echo ""
+setup
+
+# Test 1: Baseline fast path
+echo "Test 1: Baseline - repeated calls are fast"
+cd "$TEST_DIR"
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "first call ${ms}ms < ${FAST_THRESHOLD}ms"
+else fail "first call ${ms}ms >= ${FAST_THRESHOLD}ms (expected fast)"; fi
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "second call ${ms}ms < ${FAST_THRESHOLD}ms"
+else fail "second call ${ms}ms >= ${FAST_THRESHOLD}ms (expected fast)"; fi
+
+# Test 2: Touching existing file does NOT invalidate
+echo ""
+echo "Test 2: Touch existing file - still fast"
+cd "$TEST_DIR"
+touch component-oscillator-implementation.adb
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "after touch existing: ${ms}ms (fast)"
+else fail "after touch existing: ${ms}ms (expected fast)"; fi
+
+# Test 3: Creating new .do file — still fast (stale data OK)
+echo ""
+echo "Test 3: Create new .do file - still fast (serves cached data)"
+cd "$TEST_DIR"
+touch hi.do
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "after create .do: ${ms}ms (fast, stale OK)"
+else fail "after create .do: ${ms}ms (expected fast — stale data served)"; fi
+# hi.do should NOT appear yet (not in cache until next build)
+targets=$(redo what 2>&1)
+if ! echo "$targets" | grep -q "^redo hi$"; then pass "hi not in output (stale cache, expected)"
+else pass "hi already in output (pre-cached)"; fi
+rm -f hi.do
+
+# Test 4: Cold path (no persistent DB)
+echo ""
+echo "Test 4: Cold path - no persistent DB falls back gracefully"
+cd "$TEST_DIR"
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())")
+cp "$db_path" "${db_path}.bak"
+rm "$db_path"
+ms=$(time_ms redo what)
+if [ "$ms" -ge "$SLOW_THRESHOLD" ]; then pass "cold path without DB: ${ms}ms (slow, full setup)"
+else fail "cold path: ${ms}ms (expected slow >= ${SLOW_THRESHOLD}ms)"; fi
+# Should have recreated the cache
+if [ -f "$db_path" ]; then pass "persistent DB recreated after cold path"
+else fail "persistent DB NOT recreated"; fi
+# Verify targets returned
+count=$(redo what 2>&1 | wc -l)
+if [ "$count" -gt 50 ]; then pass "targets returned after cold rebuild ($count)"
+else fail "too few targets after cold rebuild ($count)"; fi
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "fast after cold rebuild: ${ms}ms"
+else fail "not fast after cold rebuild: ${ms}ms"; fi
+# Restore original full DB
+mv "${db_path}.bak" "$db_path" 2>/dev/null || true
+
+# Test 5: Cross-directory - reading one dir doesn't wipe another
+echo ""
+echo "Test 5: Cross-directory cache preservation"
+cd "$TEST_DIR"
+count_here=$(redo what 2>&1 | wc -l)
+OTHER_DIR=$(dirname "$TEST_DIR")/counter
+if [ -d "$OTHER_DIR" ]; then
+    cd "$OTHER_DIR"
+    count_other=$(redo what 2>&1 | wc -l)
+    # Read from first dir again
+    cd "$TEST_DIR"
+    count_here2=$(redo what 2>&1 | wc -l)
+    if [ "$count_here" -eq "$count_here2" ]; then
+        pass "original dir targets preserved ($count_here == $count_here2)"
+    else
+        fail "original dir targets changed ($count_here -> $count_here2)"
+    fi
+    # Read other dir again
+    cd "$OTHER_DIR"
+    count_other2=$(redo what 2>&1 | wc -l)
+    if [ "$count_other" -eq "$count_other2" ]; then
+        pass "other dir targets preserved ($count_other == $count_other2)"
+    else
+        fail "other dir targets changed ($count_other -> $count_other2)"
+    fi
+else
+    echo "  SKIP: no counter component dir found"
+fi
+
+# Test 6: Corrupt persistent DB - graceful fallback
+echo ""
+echo "Test 6: Corrupt persistent DB - falls back to slow path and recovers"
+cd "$TEST_DIR"
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())")
+cp "$db_path" "${db_path}.bak"
+echo "garbage data" > "$db_path"
+ms=$(time_ms redo what)
+if [ "$ms" -ge "$SLOW_THRESHOLD" ]; then pass "corrupt DB triggers slow path: ${ms}ms"
+else fail "corrupt DB did not trigger slow path: ${ms}ms"; fi
+# Verify targets returned on the slow path call itself
+count=$(redo what 2>&1 | wc -l)
+if [ "$count" -gt 10 ]; then pass "targets returned after corrupt fallback ($count)"
+else fail "too few targets after corrupt fallback ($count)"; fi
+# Restore full DB for remaining tests
+mv "${db_path}.bak" "$db_path" 2>/dev/null || true
+
+# Test 7: Real build updates persistent cache
+echo ""
+echo "Test 7: Real build refreshes persistent cache"
+cd "$TEST_DIR"
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())")
+mtime_before=$(stat -c %Y "$db_path" 2>/dev/null || stat -f %m "$db_path" 2>/dev/null)
+# Run a real build (just 'redo style' which is fast and triggers full setup)
+redo style 2>/dev/null || true
+sleep 1
+mtime_after=$(stat -c %Y "$db_path" 2>/dev/null || stat -f %m "$db_path" 2>/dev/null)
+if [ "$mtime_after" -ge "$mtime_before" ]; then pass "persistent DB updated after real build"
+else fail "persistent DB not updated (before=$mtime_before after=$mtime_after)"; fi
+
+# Test 8: Subdirectory targets
+echo ""
+echo "Test 8: Subdirectory targets"
+SUB_DIR="${TEST_DIR}/test"
+if [ -d "$SUB_DIR" ]; then
+    cd "$SUB_DIR"
+    # First call may be slow (subdirs not always pre-cached)
+    redo what 2>/dev/null
+    count=$(redo what 2>&1 | wc -l)
+    echo "  ${SUB_DIR##*/}: $count targets"
+    if [ "$count" -gt 0 ]; then pass "subdirectory has targets ($count)"
+    else fail "subdirectory has no targets"; fi
+else
+    echo "  SKIP: no test/ subdirectory"
+fi
+
+# Test 9: Pre-warm creates cache from scratch
+echo ""
+echo "Test 9: Pre-warm entry point creates full cache"
+cd "$TEST_DIR"
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())")
+rm -f "$db_path"
+# Pre-warm must run from the project root (where config yaml lives),
+# not from a component subdirectory, to avoid Ada source conflicts.
+project_root=$(dirname "$(dirname "$ADAMANT_CONFIGURATION_YAML")")
+(cd "$project_root" && python3 -m database.persistent_target_cache 2>/dev/null) || true
+if [ -f "$db_path" ]; then pass "pre-warm created DB"
+else fail "pre-warm did not create DB"; fi
+cd "$TEST_DIR"
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "fast after pre-warm: ${ms}ms"
+else fail "not fast after pre-warm: ${ms}ms"; fi
+
+# Test 10: Breadcrumb file exists and points to correct cache dir
+echo ""
+echo "Test 10: Breadcrumb file for shell cache discovery"
+breadcrumb="/tmp/redo-$(id -u)/cache_dir"
+if [ -f "$breadcrumb" ]; then pass "breadcrumb file exists"
+else fail "breadcrumb file missing: $breadcrumb"; fi
+breadcrumb_dir=$(cat "$breadcrumb")
+if [ -d "$breadcrumb_dir" ]; then pass "breadcrumb points to valid dir: $breadcrumb_dir"
+else fail "breadcrumb dir does not exist: $breadcrumb_dir"; fi
+if [ -f "$breadcrumb_dir/redo_target.db" ]; then pass "persistent DB found via breadcrumb"
+else fail "persistent DB not found at $breadcrumb_dir/redo_target.db"; fi
+
+# -------------------------------------------------------
+# Text Cache Tests
+# -------------------------------------------------------
+
+# Helper to get text cache path for a directory.
+# Reads the breadcrumb written by Python's get_cache_dir().
+# Uses path-as-filename encoding: /foo/bar → _foo_bar
+text_cache_path () {
+    local dir=$1
+    local breadcrumb="/tmp/redo-$(id -u)/cache_dir"
+    local cache_dir
+    cache_dir=$(cat "$breadcrumb") || { echo "ERROR: breadcrumb missing" >&2; return 1; }
+    local dir_key="${dir//\//_}"
+    echo "${cache_dir}/what/${dir_key}.txt"
+}
+
+# Test 11: Text cache file created by redo what
+echo ""
+echo "Test 11: Text cache file created by redo what"
+cd "$TEST_DIR"
+redo what 2>/dev/null
+text_file=$(text_cache_path "$TEST_DIR")
+if [ -s "$text_file" ]; then pass "text cache file exists and non-empty"
+else fail "text cache file missing or empty: $text_file"; fi
+# Verify content matches redo what output (strip "redo " prefix and header)
+what_output=$(redo what 2>&1 | tail -n +2 | sed 's/^redo //' | sort)
+cache_output=$(sort "$text_file")
+if [ "$what_output" = "$cache_output" ]; then pass "text cache content matches redo what"
+else
+    what_count=$(echo "$what_output" | wc -l)
+    cache_count=$(echo "$cache_output" | wc -l)
+    fail "text cache content differs (cache=$cache_count, what=$what_count)"
+fi
+
+# Test 12: Text cache per-directory isolation
+echo ""
+echo "Test 12: Text cache per-directory isolation"
+OTHER_DIR=$(dirname "$TEST_DIR")/counter
+if [ -d "$OTHER_DIR" ]; then
+    cd "$OTHER_DIR"
+    redo what 2>/dev/null
+    text_file_other=$(text_cache_path "$OTHER_DIR")
+    text_file_orig=$(text_cache_path "$TEST_DIR")
+    if [ -s "$text_file_other" ] && [ -s "$text_file_orig" ]; then
+        pass "both directories have text cache files"
+    else
+        fail "missing text cache (orig=$text_file_orig other=$text_file_other)"
+    fi
+    # Verify they have different content (different target counts)
+    count_orig=$(wc -l < "$text_file_orig")
+    count_other=$(wc -l < "$text_file_other")
+    if [ "$count_orig" -ne "$count_other" ]; then
+        pass "text caches differ ($count_orig vs $count_other lines)"
+    else
+        # Same count is possible but unlikely for different components
+        pass "text caches exist (both $count_orig lines)"
+    fi
+else
+    echo "  SKIP: no counter component dir found"
+fi
+
+# Test 13: Text cache invalidated when directory changes
+echo ""
+echo "Test 13: Text cache mtime validation (dir newer)"
+cd "$TEST_DIR"
+redo what 2>/dev/null  # ensure fresh text cache
+text_file=$(text_cache_path "$TEST_DIR")
+# Add a file — bumps directory mtime above text cache mtime
+sleep 1
+touch new_target.do
+dir_mtime=$(stat -c %Y "$TEST_DIR")
+text_mtime=$(stat -c %Y "$text_file")
+if [ "$dir_mtime" -gt "$text_mtime" ]; then pass "dir change detected (dir=$dir_mtime > text=$text_mtime)"
+else fail "dir change NOT detected"; fi
+# redo what should run (text cache stale) and refresh
+redo what 2>/dev/null
+text_mtime_after=$(stat -c %Y "$text_file")
+if [ "$text_mtime_after" -ge "$dir_mtime" ]; then pass "text cache refreshed after dir change"
+else fail "text cache still stale after dir change"; fi
+rm -f new_target.do
+
+# Test 14: Text cache survives redo clean
+echo ""
+echo "Test 14: Text cache in /tmp survives redo clean"
+cd "$TEST_DIR"
+text_file=$(text_cache_path "$TEST_DIR")
+# Ensure text cache exists
+redo what 2>/dev/null
+if [ -s "$text_file" ]; then
+    # Run redo clean
+    redo clean 2>/dev/null || true
+    if [ -s "$text_file" ]; then pass "text cache survives redo clean"
+    else fail "text cache deleted by redo clean"; fi
+else
+    fail "text cache missing before redo clean test"
+fi
+
+# Test 15: Shell completion reads text cache (simulated)
+echo ""
+echo "Test 15: Shell completion text_cache_read simulation"
+cd "$TEST_DIR"
+# Ensure text cache is fresh
+redo what 2>/dev/null
+# Simulate what the shell completion's text_cache_read does
+text_file=$(text_cache_path "$(pwd)")
+if [ -s "$text_file" ]; then
+    text_mtime=$(stat -c %Y "$text_file")
+    dir_mtime=$(stat -c %Y "$(pwd)")
+    if [ "$text_mtime" -ge "$dir_mtime" ]; then
+        result=$(cat "$text_file")
+        result_count=$(echo "$result" | wc -l)
+        pass "simulated text_cache_read: $result_count targets"
+    else
+        fail "text cache stale (text=$text_mtime < dir=$dir_mtime)"
+    fi
+else
+    fail "text cache file missing for shell read simulation"
+fi
+# Time the simulated shell read (cat + stat)
+start=$(date +%s%N)
+text_mtime=$(stat -c %Y "$text_file")
+dir_mtime=$(stat -c %Y "$(pwd)")
+[ "$text_mtime" -ge "$dir_mtime" ] && cat "$text_file" > /dev/null
+end=$(date +%s%N)
+shell_ms=$(( (end - start) / 1000000 ))
+echo "  Shell text cache read: ${shell_ms}ms"
+# Shell read should be much faster than even the cached Python path
+SHELL_THRESHOLD=$(( FAST_THRESHOLD / 2 ))
+[ "$SHELL_THRESHOLD" -lt 10 ] && SHELL_THRESHOLD=10
+if [ "$shell_ms" -lt "$SHELL_THRESHOLD" ]; then pass "shell read fast: ${shell_ms}ms < ${SHELL_THRESHOLD}ms"
+else fail "shell read slow: ${shell_ms}ms >= ${SHELL_THRESHOLD}ms"; fi
+
+# Test 16: Cold start — no text cache, no persistent DB
+echo ""
+echo "Test 16: Cold start - both caches missing"
+cd "$TEST_DIR"
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())")
+text_file=$(text_cache_path "$TEST_DIR")
+cp "$db_path" "${db_path}.bak"
+rm -f "$db_path" "$text_file"
+# redo what should still work (slow path) and recreate both
+ms=$(time_ms redo what)
+if [ "$ms" -ge "$SLOW_THRESHOLD" ]; then pass "cold start is slow: ${ms}ms"
+else fail "cold start unexpectedly fast: ${ms}ms"; fi
+if [ -f "$db_path" ]; then pass "persistent DB recreated"
+else fail "persistent DB NOT recreated"; fi
+if [ -s "$text_file" ]; then pass "text cache created on cold start"
+else fail "text cache NOT created on cold start"; fi
+# Subsequent call should be fast
+ms=$(time_ms redo what)
+if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "fast after cold start: ${ms}ms"
+else fail "not fast after cold start: ${ms}ms"; fi
+# Restore
+mv "${db_path}.bak" "$db_path" 2>/dev/null || true
+
+# Test 17: Build in another dir does NOT invalidate text cache here
+echo ""
+echo "Test 17: Build elsewhere does not invalidate local text cache"
+OTHER_DIR=$(dirname "$TEST_DIR")/counter
+if [ -d "$OTHER_DIR" ]; then
+    cd "$TEST_DIR"
+    redo what 2>/dev/null  # ensure fresh text cache
+    text_file=$(text_cache_path "$TEST_DIR")
+    text_mtime_before=$(stat -c %Y "$text_file")
+    # Build in a different directory
+    cd "$OTHER_DIR"
+    redo style 2>/dev/null || true
+    sleep 1
+    # Text cache for TEST_DIR should still be valid (dir mtime unchanged)
+    cd "$TEST_DIR"
+    text_mtime_after=$(stat -c %Y "$text_file")
+    dir_mtime=$(stat -c %Y "$TEST_DIR")
+    if [ "$text_mtime_after" -ge "$dir_mtime" ]; then
+        pass "text cache still valid after build elsewhere"
+    else
+        fail "text cache invalidated by build in other dir"
+    fi
+    # Should still be fast (text cache hit)
+    ms=$(time_ms redo what)
+    if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "still fast after build elsewhere: ${ms}ms"
+    else fail "not fast after build elsewhere: ${ms}ms"; fi
+else
+    echo "  SKIP: no counter dir for cross-build test"
+fi
+
+# -------------------------------------------------------
+# Text Cache Prewarm Tests (generate_text_caches)
+# -------------------------------------------------------
+
+# Test 18: Prewarm generates text caches for all DB directories
+echo ""
+echo "Test 18: Prewarm generates text caches for all persistent DB directories"
+cd "$TEST_DIR"
+# Count directories in persistent DB
+db_path=$(python3 -c "from database.persistent_target_cache import get_persistent_db_path; print(get_persistent_db_path())" 2>/dev/null)
+db_key_count=$(python3 -c "
+from database.database import database, DATABASE_MODE
+with database('$db_path', DATABASE_MODE.READ_ONLY) as db:
+    print(len(db.keys()))
+" 2>/dev/null)
+# Wipe text caches and regenerate
+cache_dir=$(cat "/tmp/redo-$(id -u)/cache_dir")
+rm -rf "$cache_dir/what"
+python3 -c "from database.persistent_target_cache import generate_text_caches; generate_text_caches()" 2>/dev/null
+text_file_count=$(ls "$cache_dir/what/" 2>/dev/null | wc -l)
+# Should have at least as many text files as DB keys (plus ancestors)
+if [ "$text_file_count" -ge "$db_key_count" ]; then
+    pass "text caches ($text_file_count) >= DB keys ($db_key_count)"
+else
+    fail "text caches ($text_file_count) < DB keys ($db_key_count)"
+fi
+
+# Test 19: Intermediate ancestor directories get text caches
+echo ""
+echo "Test 19: Intermediate ancestor directories get text caches"
+# These dirs have no build targets but should have predefined-only caches
+adamant_root="${ADAMANT_DIR}"
+adamant_src="${ADAMANT_DIR}/src"
+adamant_components="${ADAMANT_DIR}/src/components"
+all_ok=true
+for d in "$adamant_root" "$adamant_src" "$adamant_components"; do
+    tf=$(text_cache_path "$d" 2>/dev/null)
+    if [ -s "$tf" ]; then
+        content=$(cat "$tf")
+        # Should contain predefined targets
+        if echo "$content" | grep -q "^all$" && echo "$content" | grep -q "^clean$"; then
+            : # good
+        else
+            fail "text cache for $d missing predefined targets"
+            all_ok=false
+        fi
+    else
+        fail "no text cache for intermediate dir: $d"
+        all_ok=false
+    fi
+done
+if [ "$all_ok" = true ]; then pass "all intermediate dirs have valid text caches"; fi
+
+# Test 20: No text caches above build roots
+echo ""
+echo "Test 20: No text caches generated above build roots"
+spurious=false
+for bad_key in "_" "_home" "_home_user"; do
+    if [ -f "$cache_dir/what/${bad_key}.txt" ]; then
+        fail "spurious text cache: ${bad_key}.txt"
+        spurious=true
+    fi
+done
+if [ "$spurious" = false ]; then pass "no text caches above build roots"; fi
+
+# Test 21: Leaf directory text cache matches redo what output
+echo ""
+echo "Test 21: Prewarm text cache content matches redo what for leaf dir"
+cd "$TEST_DIR"
+# Get text cache content (from prewarm)
+tf=$(text_cache_path "$TEST_DIR" 2>/dev/null)
+cache_content=$(sort "$tf")
+# Get live redo what output
+live_content=$(redo what 2>&1 | tail +2 | sed 's/^redo //' | sort)
+if [ "$cache_content" = "$live_content" ]; then
+    pass "prewarm text cache matches redo what output"
+else
+    fail "prewarm text cache differs from redo what output"
+    diff <(echo "$cache_content") <(echo "$live_content") | head -5
+fi
+
+# Test 22: generate_text_caches is fast (< 500ms)
+echo ""
+echo "Test 22: Text cache generation speed"
+gen_ms=$(time_ms python3 -c "from database.persistent_target_cache import generate_text_caches; generate_text_caches()")
+echo "  generate_text_caches: ${gen_ms}ms"
+if [ "$gen_ms" -lt 5000 ]; then pass "text cache generation fast: ${gen_ms}ms < 5000ms"
+else fail "text cache generation slow: ${gen_ms}ms >= 5000ms"; fi
+
+# Test 23: Prewarm text cache for adamant_example root
+echo ""
+echo "Test 23: Prewarm covers adamant_example build root"
+example_root=$(dirname "$(dirname "$ADAMANT_CONFIGURATION_YAML")")
+tf=$(text_cache_path "$example_root" 2>/dev/null)
+if [ -s "$tf" ]; then
+    pass "adamant_example root has text cache"
+else
+    fail "adamant_example root missing text cache"
+fi
+
+# -------------------------------------------------------
+# Shell Completion Tests (__redo_completion)
+# -------------------------------------------------------
+
+# Source the completion script. Disable set -e for this section since
+# completion functions use non-zero returns for control flow.
+set +e
+source "$ADAMANT_DIR/env/redo_completion.sh" 2>/dev/null
+
+# Helper: run completion and capture COMPREPLY
+run_completion () {
+    COMPREPLY=()
+    rm -f ~/.cache/redo/what_cache_lastdir.txt
+    __redo_completion redo "$1" "" 2>/dev/null
+}
+
+# Test 24: Tilde path completion returns targets
+echo ""
+echo "Test 24: Tilde path completion returns targets"
+run_completion "~/adamant/"
+if [ "${#COMPREPLY[@]}" -gt 0 ]; then
+    # Check that results have the tilde prefix (strip trailing space from completions)
+    first="${COMPREPLY[0]%% }"
+    if [[ "$first" == "~/adamant/"* ]]; then
+        pass "tilde completion works: ${#COMPREPLY[@]} results, first=$first"
+    else
+        fail "tilde completion wrong prefix: $first"
+    fi
+else
+    fail "tilde completion returned 0 results"
+fi
+
+# Test 25: Absolute path completion returns targets
+echo ""
+echo "Test 25: Absolute path completion returns targets"
+run_completion "$ADAMANT_DIR/"
+if [ "${#COMPREPLY[@]}" -gt 0 ]; then
+    pass "absolute path completion: ${#COMPREPLY[@]} results"
+else
+    fail "absolute path completion returned 0 results"
+fi
+
+# Test 26: Build subdirectory completion uses parent cache
+echo ""
+echo "Test 26: Build subdirectory targets via parent cache"
+# Use a component directory that has build/ targets in its redo what output
+build_test_dir="$TEST_DIR"
+has_build=$(cd "$build_test_dir" && redo what 2>&1 | grep "^redo build/" | head -1)
+if [ -n "$has_build" ]; then
+    run_completion "$build_test_dir/build/"
+    if [ "${#COMPREPLY[@]}" -gt 0 ]; then
+        pass "build/ completion from parent cache: ${#COMPREPLY[@]} targets"
+    else
+        fail "build/ completion returned 0 targets"
+    fi
+else
+    echo "  SKIP: no build targets in $build_test_dir"
+fi
+
+# Test 27: Nonexistent directory is fast (no slow redo subprocess)
+echo ""
+echo "Test 27: Nonexistent directory completes fast"
+start_ms=$(date +%s%3N)
+run_completion "$ADAMANT_DIR/this_dir_does_not_exist/"
+end_ms=$(date +%s%3N)
+elapsed=$((end_ms - start_ms))
+if [ "$elapsed" -lt 500 ]; then
+    pass "nonexistent dir fast: ${elapsed}ms, ${#COMPREPLY[@]} results"
+else
+    fail "nonexistent dir slow: ${elapsed}ms"
+fi
+
+# Test 28: Deep build path completion (build/obj/...)
+echo ""
+echo "Test 28: Deep build path completion"
+# Use a component that has build/obj targets
+test_comp="$ADAMANT_DIR/src/components/command_rejector"
+if [ -d "$test_comp" ]; then
+    # Ensure text cache exists
+    cd "$test_comp" && redo what >/dev/null 2>&1
+    cd "$OLDPWD"
+    run_completion "$test_comp/build/"
+    build_count=${#COMPREPLY[@]}
+    run_completion "$test_comp/build/obj/"
+    obj_count=${#COMPREPLY[@]}
+    if [ "$build_count" -gt 0 ]; then
+        pass "build/ has $build_count targets, build/obj/ has $obj_count targets"
+    else
+        fail "build/ returned 0 targets for command_rejector"
+    fi
+else
+    echo "  SKIP: command_rejector not found"
+fi
+
+# Test 29: Completion results include directory entries
+echo ""
+echo "Test 29: Completion includes subdirectories"
+run_completion "$ADAMANT_DIR/"
+dirs_found=false
+for r in "${COMPREPLY[@]}"; do
+    if [[ "$r" == */ ]]; then
+        dirs_found=true
+        break
+    fi
+done
+if [ "$dirs_found" = true ]; then
+    pass "completion includes directory entries"
+else
+    fail "no directory entries in completion results"
+fi
+
+# Test 30: Partial target name completion
+echo ""
+echo "Test 30: Partial target name filters correctly"
+run_completion "$ADAMANT_DIR/cl"
+all_match=true
+for r in "${COMPREPLY[@]}"; do
+    base="${r##*/}"
+    base="${base%% }"  # strip trailing space
+    if [[ "$base" != cl* ]]; then
+        fail "partial completion mismatch: $r does not start with cl"
+        all_match=false
+        break
+    fi
+done
+if [ "$all_match" = true ] && [ "${#COMPREPLY[@]}" -gt 0 ]; then
+    pass "partial completion: ${#COMPREPLY[@]} matches for 'cl' (clean, clean_all, clear_cache)"
+else
+    [ "$all_match" = true ] && fail "partial completion returned 0 results"
+fi
+
+# -------------------------------------------------------
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo "SOME TESTS FAILED"
+    exit 1
+else
+    echo "ALL TESTS PASSED"
+fi


### PR DESCRIPTION
## Summary

Dramatically speeds up `redo what` and `redo <TAB>` completion by caching target data across sessions.

### Before
- Every tab completion invoked `redo what` → full Python setup → **~300-400ms**

### After
- **~15ms** for cached tab completions (shell reads text file, no Python subprocess)
- **~50ms** for `redo what` (reads persistent DB, skips setup)
- **~300ms** cold path (no cache, falls back to single-directory setup)
- **~4s** one-time pre-warm on `source env/activate` (backgrounded)

### How it works

**Layer 1: Persistent target DB** (`persistent_target_cache.py`)
- After each build, the session's `redo_target.db` is copied to `/tmp/redo-<uid>/<hash>/redo_target.db`
- `redo what` reads this persistent DB directly, skipping the expensive `_setup()` entirely
- Cache key: `ADAMANT_CONFIGURATION_YAML` + `TARGET` env vars (shared across subdirectories, separate per cross-compile target)
- Corrupt DB recovery: catches `unqlite.UnQLiteError` specifically, falls back to slow path. Other exceptions (permissions, lock contention) leave existing DB intact.
- Pre-warm on activate: `python3 -m database.persistent_target_cache` (backgrounded, only if no cache exists)

**Layer 2: Text cache for shell completion** (`build_what.py`, `redo_completion.sh`)
- `redo what` writes its output to a plain text file using path-as-filename encoding (`/foo/bar` → `_foo_bar.txt`)
- Shell completion reads this with `cat` + `stat` mtime check — no Python invocation at all
- Text cache is checked **before** `what_predef_parsed` (which spawns a Python subprocess), eliminating ~34ms on cache hit
- Invalidated when directory mtime is newer (files added/removed)

**Breadcrumb for shell/Python coordination** (`get_cache_dir()`)
- Python writes the resolved cache directory to `/tmp/redo-<uid>/cache_dir`
- Shell scripts (`redo_completion.sh`, `env/activate`) read this breadcrumb instead of recomputing the hash — single source of truth, no duplicated logic between languages

**Build cache guard** (`_REDO_WHAT_ACTIVE`)
- `_delayed_cleanup` saves the persistent DB after builds, but skips when `redo what` is the caller (it handles its own per-directory updates)
- Uses `_REDO_WHAT_ACTIVE` env var instead of checking `BUILD_PATH`, since `BUILD_PATH` can be legitimately set by projects

### Commits
1. **Persistent target DB** — `persistent_target_cache.py` (new), hooks in `_setup.py`, `build_what.py`, `activate`
2. **Text cache + shell completion rewrite** — `redo_completion.sh` fast-path reorder, `save_text_cache()` in `build_what.py`, breadcrumb discovery, path-as-filename encoding
3. **Test suite** — 17 tests, 35 assertions. Timing thresholds calibrated dynamically per machine.

### Test suite
```
bash redo/test/persistent_cache/test_persistent_cache.sh
```
Covers: fast path, touch stability, stale-OK behavior, cold path recovery, cross-directory isolation, corrupt DB fallback, build refresh, subdirectory targets, pre-warm, breadcrumb discovery, text cache correctness, per-directory isolation, mtime validation, redo clean survival, shell read speed, cold start, cross-build isolation.