### PR TITLE
Add skip_validation to byte/poly fields to enable Always_Valid

### DIFF
--- a/src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml
+++ b/src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True

--- a/src/types/ccsds/ccsds_space_packet.record.yaml
+++ b/src/types/ccsds/ccsds_space_packet.record.yaml
@@ -16,3 +16,4 @@ fields:
     format: U8x{{ ccsds_packet_buffer_size }}
     variable_length: Header.Packet_Length
     variable_length_offset: 1
+    skip_validation: True

--- a/src/types/command/invalid_command_info.record.yaml
+++ b/src/types/command/invalid_command_info.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data, or length when Errant_Field_Number is 2**32.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True

--- a/src/types/parameter/invalid_parameter_info.record.yaml
+++ b/src/types/parameter/invalid_parameter_info.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data, or length when Errant_Field_Number is 2**32.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True


### PR DESCRIPTION
## Summary

- Adds `skip_validation: True` to four records whose only blocker for `Always_Valid = True` was a `Byte_Array` or `Basic_Types.Poly_Type` field that the generator conservatively treats as not-always-valid.
- **Hot path**: `Ccsds_Space_Packet.T` now flips to `Always_Valid = True`. Every component dispatching on it as a command arg, parameter, or product extraction target will elide `Validation.Valid` at compile time via the `or else Always_Valid` short-circuit from #163.
- **Consistency**: the three `invalid_*_info` records align with the existing `skip_validation: True` pattern on every other `Basic_Types.Poly_*` field in the framework (`packed_poly_type`, `packed_poly_64_type`, `data_product_poly_type`, `data_product_poly_event`, `packed_exception_occurrence`, etc.).

## Files changed

| File | Field |
|---|---|
| `src/types/ccsds/ccsds_space_packet.record.yaml` | `Data` |
| `src/types/command/invalid_command_info.record.yaml` | `Errant_Field` |
| `src/types/parameter/invalid_parameter_info.record.yaml` | `Errant_Field` |
| `src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml` | `Errant_Field` |

## Verification

For each record I regenerated the `.ads` and confirmed the emitted `Always_Valid` constant resolves to `True` at compile time:

- `Ccsds_Space_Packet.Always_Valid = Ccsds_Primary_Header.Always_Valid and then True` — and `Ccsds_Primary_Header` independently evaluates `True` via the 7 full-width field checks (all fields carefully sized to match their bit widths: `Three_Bit_Version_Type` in U3, enums at full literal count for E1/E2, mod-2^11 in U11, mod-2^14 in U14, `Unsigned_16` in U16).
- Each `invalid_*_info` record emits `(Id full-width) and then (Errant_Field_Number full-width) and then True`.

## Scope

Only the four records above. Every other `Byte_Array` or `Poly` field I audited in the framework either already carries `skip_validation: True`, or is in a record anchored to `False` by a *separate* legitimately range-constrained field (e.g. `Command_Arg_Buffer_Length_Type`, `Region_Length_Type`, config-bounded buffer lengths) — those anchors represent real validation that should stay in place.

## Test plan

- [ ] `redo all` in each affected directory builds clean
- [ ] `redo test_all` from repo root passes (in particular the record tests under `gen/test/records/` that exercise the `Always_Valid` generator logic)
- [ ] `redo style_all` passes
- [ ] Spot-check a component that takes `Ccsds_Space_Packet.T` as a command arg and confirm the dispatch template's `or else Always_Valid` short-circuit is visible in the generated body

🤖 Generated with [Claude Code](https://claude.com/claude-code)