### PR TITLE
Fix off-by-one in Get_Field for nested packed type fields

### DIFF
--- a/gen/templates/array/name-validation.adb
+++ b/gen/templates/array/name-validation.adb
@@ -227,7 +227,7 @@ package body {{ name }}.Validation is
 {% if endianness in ["either", "big"] %}
    function Get_Field (Src : in T; Field : in Interfaces.Unsigned_32) return Basic_Types.Poly_Type is
 {% if element.is_packed_type %}
-      Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type (Field / {{ element.type_model.num_fields }});
+      Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type ((Field - 1) / {{ element.type_model.num_fields }});
       Remainder : Unsigned_32 := 0;
       To_Return : Basic_Types.Poly_Type;
 {% else %}
@@ -272,7 +272,7 @@ package body {{ name }}.Validation is
 {% if endianness in ["either", "little"] %}
    function Get_Field (Src : in T_Le; Field : in Interfaces.Unsigned_32) return Basic_Types.Poly_Type is
 {% if element.is_packed_type %}
-      Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type (Field / {{ element.type_model.num_fields }});
+      Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type ((Field - 1) / {{ element.type_model.num_fields }});
       Remainder : Unsigned_32 := 0;
       To_Return : Basic_Types.Poly_Type;
 {% else %}

--- a/gen/templates/record/name-validation.adb
+++ b/gen/templates/record/name-validation.adb
@@ -430,7 +430,7 @@ package body {{ name }}.Validation is
 {% for field in fields.values() %}
 {% if field.is_packed_type %}
          when {{ field.start_field_number }} .. {{ field.end_field_number }} =>
-            To_Return := {{ field.type_package }}.Validation.Get_Field (Src.{{ field.name }}, Field - {{ field.start_field_number + 1 }});
+            To_Return := {{ field.type_package }}.Validation.Get_Field (Src.{{ field.name }}, Field - {{ field.start_field_number - 1 }});
 {% else %}
          when {{ field.start_field_number }} =>
             declare
@@ -477,7 +477,7 @@ package body {{ name }}.Validation is
 {% for field in fields.values() %}
 {% if field.is_packed_type %}
          when {{ field.start_field_number }} .. {{ field.end_field_number }} =>
-            To_Return := {{ field.type_package }}.Validation.Get_Field (Src.{{ field.name }}, Field - {{ field.start_field_number + 1 }});
+            To_Return := {{ field.type_package }}.Validation.Get_Field (Src.{{ field.name }}, Field - {{ field.start_field_number - 1 }});
 {% else %}
          when {{ field.start_field_number }} =>
             declare

--- a/gen/test/arrays/test/test.adb
+++ b/gen/test/arrays/test/test.adb
@@ -208,6 +208,23 @@ begin
    pragma Assert (not Enum_Array.Validation.Valid (Enum_Mut, Field_Number, Enum_Mut'Last - 2, Enum_Mut'Last), "Enum is valid, but should not be 7.");
    Put_Line ("passed.");
 
+   -- Verify that Get_Field maps field numbers to the correct array element
+   Put_Line ("Testing Get_Field round-trip for packed array element index: ");
+   declare
+      -- Complex_Array elements are Aa.T with 3 sub-fields each (One, Two, Three).
+      -- Craft bytes so element 0 has valid One/Two but invalid Three (= 3, out of range 5..2056).
+      -- This makes field 3 (element 0, sub-field 3) the first invalid field.
+      -- Field 3 is a multiple of num_fields, which exercises the element index edge case.
+      C_Bytes_Rt : constant Complex_Array.Serialization.Byte_Array := [0 => 0, 1 => 19, 2 => 0, 3 => 3, others => 0];
+      Complex_Rt : constant Complex_Array.T := Complex_Array.Serialization.From_Byte_Array (C_Bytes_Rt);
+   begin
+      pragma Assert (not Complex_Array.Validation.Valid (Complex_Rt, Field_Number), "Complex_Rt is valid, but should not be.");
+      pragma Assert (Field_Number = 3, "Complex_Rt field_Number is wrong.");
+      Put_Line (Poly2bytestring (Complex_Array.Validation.Get_Field (Complex_Rt, Field_Number)));
+      pragma Assert (Complex_Array.Validation.Get_Field (Complex_Rt, Field_Number) = [0, 0, 0, 0, 3, 0, 0, 0], "Get_Field value mismatch.");
+   end;
+   Put_Line ("passed.");
+
    Put_Line ("Testing serialization/deserialization... ");
    S_Bytes := Simple_Array.Serialization.To_Byte_Array (Simple);
    Simple2 := Simple_Array.Serialization.From_Byte_Array (S_Bytes);

--- a/gen/test/records/test/test.adb
+++ b/gen/test/records/test/test.adb
@@ -113,7 +113,7 @@ procedure Test is
    -- Record array definitions:
    A_Bytes : Aa.Serialization.Byte_Array := [0 => 255, others => 0];
    B_Bytes : Bb.Serialization.Byte_Array := [others => 0];
-   C_Bytes : Cc.Serialization.Byte_Array := [others => 0];
+   C_Bytes : Cc.Serialization.Byte_Array := [5 => 255, others => 0];
    V_Bytes : Simple_Variable.Serialization.Byte_Array := [0 => 2, others => 255];
    V_Bytes2 : Simple_Variable.Serialization.Byte_Array := [others => 0];
    V_Bytes3 : Simple_Variable.Serialization.Byte_Array := [others => 0];
@@ -258,7 +258,7 @@ begin
    pragma Assert (Bb.Validation.Get_Field (B, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "B's polytype field is wrong.");
    pragma Assert (not Cc.Validation.Valid (C, Field_Number), "C is valid, but should not be.");
    pragma Assert (Field_Number = 3, "C field_Number is wrong.");
-   pragma Assert (Cc.Validation.Get_Field (C, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "C's polytype field is wrong.");
+   pragma Assert (Cc.Validation.Get_Field (C, Field_Number) = [0, 0, 0, 0, 255, 0, 0, 0], "C's polytype field is wrong.");
    pragma Assert (not Simple_Variable.Validation.Valid (V, Field_Number), "V is valid, but should not be.");
    pragma Assert (Field_Number = 2, "V field_Number is wrong.");
    Put_Line (Poly2bytestring (Simple_Variable.Validation.Get_Field (V, Field_Number)));
@@ -266,7 +266,7 @@ begin
    pragma Assert (not Simple_Variable_Holder.Validation.Valid (Sv, Field_Number), "V is valid, but should not be.");
    pragma Assert (Field_Number = 3, "V field_Number is wrong.");
    Put_Line (Poly2bytestring (Simple_Variable_Holder.Validation.Get_Field (Sv, Field_Number)));
-   pragma Assert (Simple_Variable_Holder.Validation.Get_Field (Sv, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "V's polytype field is wrong.");
+   pragma Assert (Simple_Variable_Holder.Validation.Get_Field (Sv, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "SVH's polytype field is wrong.");
    pragma Assert (not Simple_Variable_Offset.Validation.Valid (Ov, Field_Number), "V is valid, but should not be.");
    pragma Assert (Field_Number = 2, "V field_Number is wrong.");
    Put_Line (Poly2bytestring (Simple_Variable_Offset.Validation.Get_Field (Ov, Field_Number)));
@@ -274,15 +274,25 @@ begin
    pragma Assert (not Simple_Variable_Array.Validation.Valid (Av, Field_Number), "V is valid, but should not be.");
    pragma Assert (Field_Number = 2, "V field_Number is wrong." & Interfaces.Unsigned_32'Image (Field_Number));
    Put_Line (Poly2bytestring (Simple_Variable_Array.Validation.Get_Field (Av, Field_Number)));
-   pragma Assert (Simple_Variable_Array.Validation.Get_Field (Av, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "V's polytype field is wrong.");
+   pragma Assert (Simple_Variable_Array.Validation.Get_Field (Av, Field_Number) = [0, 0, 0, 0, 255, 0, 0, 0], "SVA's polytype field is wrong.");
    pragma Assert (not Simple_Variable_Array_Le.Validation.Valid (Av_Le, Field_Number), "AV_LE is valid, but should not be.");
    pragma Assert (Field_Number = 2, "AV_LE field_Number is wrong." & Interfaces.Unsigned_32'Image (Field_Number));
    Put_Line (Poly2bytestring (Simple_Variable_Array_Le.Validation.Get_Field (Av_Le, Field_Number)));
-   pragma Assert (Simple_Variable_Array_Le.Validation.Get_Field (Av_Le, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "AV_LE's polytype field is wrong.");
+   pragma Assert (Simple_Variable_Array_Le.Validation.Get_Field (Av_Le, Field_Number) = [0, 0, 0, 0, 255, 0, 0, 0], "SVA_LE's polytype field is wrong.");
    pragma Assert (not Simple_Variable_Holder_Le.Validation.Valid (Sv_Le, Field_Number), "SV_LE is valid, but should not be.");
    pragma Assert (Field_Number = 3, "SV_LE field_Number is wrong.");
    Put_Line (Poly2bytestring (Simple_Variable_Holder_Le.Validation.Get_Field (Sv_Le, Field_Number)));
-   pragma Assert (Simple_Variable_Holder_Le.Validation.Get_Field (Sv_Le, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "SV_LE's polytype field is wrong.");
+   pragma Assert (Simple_Variable_Holder_Le.Validation.Get_Field (Sv_Le, Field_Number) = [0, 0, 0, 0, 0, 0, 0, 0], "SVH_LE's polytype field is wrong.");
+   Put_Line ("passed.");
+   Put_Line ("");
+
+   -- Verify that Get_Field returns the correct sub-field value for nested packed
+   -- types in Cc.
+   -- Cc field layout: C(1), A.One(2), A.Two(3), A.Three(4), B.Element(5), B.Element2(6)
+   Put_Line ("Testing Get_Field round-trip for nested packed record fields: ");
+   pragma Assert (Cc.Validation.Get_Field (C, 2) = [0, 0, 0, 0, 0, 0, 0, 0], "Get_Field  A.One value mismatch.");
+   pragma Assert (Cc.Validation.Get_Field (C, 3) = [0, 0, 0, 0, 255, 0, 0, 0], "Get_Field A.Two value mismatch.");
+   pragma Assert (Cc.Validation.Get_Field (C, 5) = [0, 0, 0, 0, 0, 0, 0, 0], "Get_Field B.Element value mismatch.");
    Put_Line ("passed.");
    Put_Line ("");
 


### PR DESCRIPTION
## Summary

- Fixes an off-by-one error in the record validation code generator template (`gen/templates/record/name-validation.adb`) where `Get_Field` computed the wrong subtraction offset when dispatching to nested packed types (both arrays and records)
- The generated code used `Field - (start_field_number + 1)` instead of `Field - (start_field_number - 1)`, causing the relative field index to underflow in `Unsigned_32` arithmetic and silently read out-of-bounds memory (due to `pragma Suppress (Range_Check)`)
- This makes `Get_Field` consistent with `Valid`, which already correctly uses `start_field_number - 1` as the base offset