### PR TITLE
Add Byte_Array subprograms to packet creation template

### DIFF
--- a/gen/templates/packets/name_packets.adb
+++ b/gen/templates/packets/name_packets.adb
@@ -11,9 +11,6 @@ with Serializer;
 {% if typeless_packet or variable_length_types %}
 with Byte_Array_Util;
 {% endif %}
-{% if not typeless_packet and variable_length_types %}
-with Basic_Types;
-{% endif %}
 
 package body {{ name }} is
    use Packet_Types;
@@ -127,13 +124,54 @@ package body {{ name }} is
 
       return P;
    end {{ p.name }}_Truncate;
+
+   not overriding function {{ p.name }}_Bytes (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in Basic_Types.Byte_Array; Pkt : out Packet.T) return Serialization_Status is
+   begin
+      -- Initialize the packet:
+      Pkt := (
+         Header => (
+            Id => Self.Get_{{ p.name }}_Id,
+            Time => Timestamp,
+            Sequence_Count => Self.{{ p.name }}_Sequence_Count,
+            Buffer_Length => 0
+         ),
+         Buffer => [others => 0]
+      );
+      -- Make sure the passed in buffer will fit into the packet:
+      if Buf'Length > Pkt.Buffer'Length then
+         return Failure;
+      end if;
+      -- Copy over the data and update the packet length and sequence count:
+      Pkt.Header.Buffer_Length := Buf'Length;
+      Pkt.Buffer (Packet_Buffer_Type'First .. Packet_Buffer_Type'First + Buf'Length - 1) := Buf;
+      Self.{{ p.name }}_Sequence_Count := @ + 1;
+      return Success;
+   end {{ p.name }}_Bytes;
+{% else %}
+{% if p.type_model %}
+   not overriding function {{ p.name }} (Self : in out Instance; Timestamp : in Sys_Time.T; Item : in {{ p.type }}) return Packet.T is
+   begin
+      return Self.{{ p.name }}_Bytes (Timestamp, {{ p.type_package }}.Serialization.To_Byte_Array (Item));
+   end {{ p.name }};
+
+   not overriding function {{ p.name }}_Bytes (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in {{ p.type_package }}.Serialization.Byte_Array) return Packet.T is
+      P : Packet.T := (
+         Header => (
+            Id => Self.Get_{{ p.name }}_Id,
+            Time => Timestamp,
+            Sequence_Count => Self.{{ p.name }}_Sequence_Count,
+            Buffer_Length => Buf'Length
+         ),
+         Buffer => [others => 0]
+      );
+   begin
+      P.Buffer (P.Buffer'First .. P.Buffer'First + Buf'Length - 1) := Buf;
+      Self.{{ p.name }}_Sequence_Count := @ + 1;
+      return P;
+   end {{ p.name }}_Bytes;
 {% else %}
    not overriding function {{ p.name }} (Self : in out Instance; Timestamp : in Sys_Time.T; Item : in {{ p.type }}) return Packet.T is
-{% if p.type_model %}
-      package Packet_Serializer renames {{ p.type_package }}.Serialization;
-{% else %}
       package Packet_Serializer is new Serializer ({{ p.type }});
-{% endif %}
       P : Packet.T := (
          Header => (
             Id => Self.Get_{{ p.name }}_Id,
@@ -148,6 +186,7 @@ package body {{ name }} is
       Self.{{ p.name }}_Sequence_Count := @ + 1;
       return P;
    end {{ p.name }};
+{% endif %}
 {% endif %}
 {% else %}
    not overriding function {{ p.name }} (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in Basic_Types.Byte_Array; Pkt : out Packet.T) return Serialization_Status is

--- a/gen/templates/packets/name_packets.ads
+++ b/gen/templates/packets/name_packets.ads
@@ -17,10 +17,8 @@ with {{ include }};
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if typeless_packet %}
-with Basic_Types;
-{% endif %}
 {% if typeless_packet or variable_length_types %}
+with Basic_Types;
 with Serializer_Types; use Serializer_Types;
 {% endif %}
 {% if description %}
@@ -82,8 +80,14 @@ package {{ name }} is
    -- Special function, which will fill the Packet.T type as much as possible, and then drop any remaining bytes found in the
    -- input item. Sometimes this is desirable over returning a Serialization_Error, like what would occur with the above function.
    not overriding function {{ p.name }}_Truncate (Self : in out Instance; Timestamp : in Sys_Time.T; Item : in {{ p.type }}) return Packet.T;
+   -- Byte array variant for when the data is already serialized:
+   not overriding function {{ p.name }}_Bytes (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in Basic_Types.Byte_Array; Pkt : out Packet.T) return Serialization_Status;
 {% else %}
    not overriding function {{ p.name }} (Self : in out Instance; Timestamp : in Sys_Time.T; Item : in {{ p.type }}) return Packet.T;
+{% if p.type_model %}
+   -- Byte array variant for when the data is already serialized:
+   not overriding function {{ p.name }}_Bytes (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in {{ p.type_package }}.Serialization.Byte_Array) return Packet.T;
+{% endif %}
 {% endif %}
 {% else %}
    not overriding function {{ p.name }} (Self : in out Instance; Timestamp : in Sys_Time.T; Buf : in Basic_Types.Byte_Array; Pkt : out Packet.T) return Serialization_Status;


### PR DESCRIPTION
## Summary

- For variable-length typed packets, generate a `_Bytes` function that accepts `Basic_Types.Byte_Array` and returns `Serialization_Status` (Failure if the buffer exceeds packet capacity).
- For fixed-length typed packets, generate a `_Bytes` function that accepts the exactly-sized `Serialization.Byte_Array`. The existing typed function delegates through `_Bytes`, eliminating code duplication.
- These enable callers that already have serialized data (e.g. from validation) to create packets without a redundant deserialize/re-serialize round-trip.

## Test plan

- [ ] CI passes (style_all, test_all, build_user_guide)
- [ ] Verify generated code for a fixed-length packet type delegates through `_Bytes`
- [ ] Verify generated code for a variable-length packet type has separate `_Bytes` with status return

🤖 Generated with [Claude Code](https://claude.com/claude-code)