### PR TITLE
Add ignored and unconnected connector counts to assembly HTML summaries

### DIFF
--- a/gen/models/assembly.py
+++ b/gen/models/assembly.py
@@ -579,6 +579,8 @@ class assembly(subassembly):
         self.task_total_secondary_stack_size = (
             0  # sum of all secondary stack sizes of all tasks in assembly
         )
+        self.num_unconnected_connectors = 0
+        self.num_ignored_connectors = 0
 
         # Lists:
         self.component_kind_dict = {
@@ -773,33 +775,33 @@ class assembly(subassembly):
                         if connector.count > 1:
                             for index0 in range(connector.count):
                                 index = index0 + 1
-                                if (
-                                    not connector.connected(index)
-                                    and not connector.ignored(index)
-                                    and not self.shallow_load
-                                ):
+                                if connector.ignored(index):
+                                    self.num_ignored_connectors += 1
+                                elif not connector.connected(index):
+                                    self.num_unconnected_connectors += 1
+                                    if not self.shallow_load:
+                                        self.warn(
+                                            "component '"
+                                            + component.instance_name
+                                            + "' has unattached connector '"
+                                            + connector.name
+                                            + "["
+                                            + str(index)
+                                            + "]'."
+                                        )
+                        else:
+                            if connector.ignored():
+                                self.num_ignored_connectors += 1
+                            elif not connector.connected():
+                                self.num_unconnected_connectors += 1
+                                if not self.shallow_load:
                                     self.warn(
                                         "component '"
                                         + component.instance_name
                                         + "' has unattached connector '"
                                         + connector.name
-                                        + "["
-                                        + str(index)
-                                        + "]'."
+                                        + "'."
                                     )
-                        else:
-                            if (
-                                not connector.connected()
-                                and not connector.ignored()
-                                and not self.shallow_load
-                            ):
-                                self.warn(
-                                    "component '"
-                                    + component.instance_name
-                                    + "' has unattached connector '"
-                                    + connector.name
-                                    + "'."
-                                )
 
             # We almost always want to run the following code, however there are very special times, to avoid
             # circular dependencies, that a generator might disable the running of this code. That is why

--- a/gen/templates/assembly/name_components.html
+++ b/gen/templates/assembly/name_components.html
@@ -17,6 +17,8 @@
         <li><b>Number of Components with Packets:</b> {{ component_kind_dict['packets']|length }}</li>
         <li><b>Number of Components with Faults:</b> {{ component_kind_dict['faults']|length }}</li>
         <li><b>Number of Connections:</b> {{ connections|length }}</li>
+        <li><b>Number of Unconnected Connectors:</b> {{ num_unconnected_connectors }}</li>
+        <li><b>Number of Ignored Connectors:</b> {{ num_ignored_connectors }}</li>
         <li><b>Number of Events:</b> {{ events|length }}</li>
         <li><b>Number of Commands:</b> {{ commands|length }}</li>
         <li><b>Number of Data Products:</b> {{ data_products|length }}</li>

--- a/gen/templates/assembly/name_connections.html
+++ b/gen/templates/assembly/name_connections.html
@@ -5,6 +5,8 @@
       <ul>
         <li><b>Number of Components:</b> {{ components|length }}</li>
         <li><b>Number of Connections:</b> {{ connections|length }}</li>
+        <li><b>Number of Unconnected Connectors:</b> {{ num_unconnected_connectors }}</li>
+        <li><b>Number of Ignored Connectors:</b> {{ num_ignored_connectors }}</li>
       </ul>
 {% endblock %}
 {% block head %}


### PR DESCRIPTION
## Summary

Add assembly-level counts for:

- unconnected connectors
- ignored connectors

and surface both in the summary blocks for:

- `name_components.html`
- `name_connections.html`

## What changed

- compute `num_unconnected_connectors` and `num_ignored_connectors` in `gen/models/assembly.py`
- add both values to the assembly components HTML summary
- add both values to the assembly connections HTML summary

## Semantics

Counts are based on connector slots / indices:

- **ignored** = connector slot marked ignored
- **unconnected** = connector slot that is neither connected nor ignored

This matches the existing unattached-connector warning logic.

## Test

Verified by generating real assembly HTML in the example container for:

- `src/components/command_router/doc/assembly/context.assembly.yaml`

Observed rendered values:

- `Number of Unconnected Connectors: 10`
- `Number of Ignored Connectors: 0`

on both:

- components page
- connections page
