### PR TITLE
Fix packed array validation template alignment issue

### DIFF
--- a/gen/models/array.py
+++ b/gen/models/array.py
@@ -108,6 +108,71 @@ class array(type):
                 + "total packed array itself must be byte aligned."
             )
 
+        # Compute a static literal that is an upper bound on the
+        # alignment GNAT will pick for this packed array's T (and
+        # T_Le) types. The validation autocode uses this literal in
+        # `with Alignment => ...` aspects on local Byte_Array copies
+        # that are then overlaid by `R : T`. The safety condition for
+        # the overlay (RM 13.3(13/3)) is met when `our_literal >=
+        # T'Alignment` and `our_literal mod T'Alignment = 0`. Both
+        # follow from "our literal is a power of 2 >= T'Alignment"
+        # because GNAT-RM 10.1 guarantees T'Alignment is also a power
+        # of 2 (any pow2 >= a smaller pow2 is a multiple of it).
+        #
+        # Records always have Alignment => 1 by GNAT-RM 13.4. For
+        # everything else we cannot match both targets exactly with
+        # one formula, so we pick a literal that is an upper
+        # bound on both. Specifically:
+        #   * byte-aligned: bytes_per_elem & -bytes_per_elem
+        #   * sub-byte: next_pow2 of total array byte size
+        # Over-aligning is harmless beyond a small stack-space cost
+        # for the local Byte_Array copy. Under-aligning would be
+        # erroneous. The pragma at every overlay site catches any
+        # under-alignment at compile time.
+        #
+        # The `n & -n` idiom isolates the lowest set bit, which for
+        # any positive integer is the greatest power of 2 dividing
+        # it.
+        if self.element.is_packed_type and not isinstance(
+            self.element.type_model, array
+        ):
+            # Packed-record element: T'Alignment = 1, also enforced
+            # by the parallel pragma Compile_Time_Error in the
+            # record-validation template.
+            self.required_alignment = 1
+        elif self.element.size % 8 == 0:
+            # Byte-aligned element: primitive (matches T'Alignment
+            # exactly) or nested packed array (an upper bound; the
+            # pragma at the overlay site enforces correctness).
+            bytes_per_elem = self.element.size // 8
+            self.required_alignment = bytes_per_elem & -bytes_per_elem
+        else:
+            # Sub-byte primitive (e.g. U10): GNAT picks next_pow2 of
+            # the array's total byte size. Round up to next power of
+            # 2: 1<<((x-1).bit_length()) for x>=1.
+            total_bytes = self.size // 8
+            self.required_alignment = 1 << max(0, (total_bytes - 1).bit_length())
+
+        # Sanity-check: Required_alignment must be a power
+        # of 2. Per the GNAT Reference Manual section 10.1 (Alignment
+        # Clauses): "GNAT requires that all alignment clauses specify
+        # 0 or a power of 2, and all default alignments are always a
+        # power of 2." So T'Alignment is also pow2, and together with
+        # this assertion that means `our_literal >= T'Alignment` (the
+        # template's Compile_Time_Error) implies `our_literal mod
+        # T'Alignment = 0` -- any pow2 >= a smaller pow2 is a
+        # multiple of it.
+        assert (
+            self.required_alignment > 0
+            and (self.required_alignment & (self.required_alignment - 1)) == 0
+        ), (
+            "Required_alignment="
+            + str(self.required_alignment)
+            + " for array '"
+            + self.name
+            + "' is not a power of 2, but must be per GNAT RM 10.1"
+        )
+
         # Make sure the array does not contain a variable length type:
         if self.variable_length:
             raise ModelException(

--- a/gen/templates/array/name-validation.adb
+++ b/gen/templates/array/name-validation.adb
@@ -9,6 +9,8 @@
 with Byte_Array_Util;
 
 {% endif %}
+-- For runtime alignment checks on Bytes / Aligned addresses:
+with System.Storage_Elements;
 {% if packed_type_includes %}
 -- Record Field Includes:
 {% for include in packed_type_includes %}
@@ -18,6 +20,66 @@ with {{ include }}.Validation;
 {% endif %}
 package body {{ name }}.Validation is
 
+   -- Packed arrays (unlike packed records) are not allowed to have
+   -- Alignment => 1 unless their component size is 1, so GNAT picks
+   -- a non-trivial T'Alignment for most cases. Overlaying T on a
+   -- Byte_Array (natural alignment 1) at a runtime address that
+   -- doesn't satisfy T'Alignment is erroneous per Ada 2022 RM
+   -- 13.3(13/3):
+   --
+   --   "If an Address is specified, it is the programmer's
+   --   responsibility to ensure that the address is valid and
+   --   appropriate for the entity and its use; otherwise, program
+   --   execution is erroneous."
+   --   (http://www.ada-auth.org/standards/22rm/html/RM-13-3.html)
+   --
+   -- In practice this manifests as silent garbage on x86 hosts (GNAT
+   -- folds the misalignment) and as traps or garbage reads on
+   -- alignment-strict bareboard targets.
+   --
+   -- The autocode below picks one of three patterns depending on the
+   -- element shape (computed in gen/models/array.py as
+   -- `required_alignment`):
+   --
+   --   * Packed-record element (T'Alignment = 1) -- direct overlay,
+   --     no copy needed; any byte address satisfies the requirement.
+   --
+   --   * Byte-aligned primitive (Short_Float, Unsigned_32, ...) --
+   --     fast path overlays directly when Bytes' runtime address
+   --     already satisfies T'Alignment, slow path copies into an
+   --     aligned local Byte_Array and overlays on the copy.
+   --
+   --   * Sub-byte primitive (e.g. T'Component_Size = 10) -- always
+   --     copy into the aligned local.
+   --
+   -- We assume that the required alignment computed in the model
+   -- ({{ required_alignment }}) is compatible with the alignment chosen by
+   -- the compiler for T (and T_Le) -- i.e. that T'Alignment divides
+   -- {{ required_alignment }}. We verify that here with a `pragma
+   -- Compile_Time_Error`. We know that T'Alignment must be a power
+   -- of 2 via the GNAT Reference Manual section 10.1 (Alignment
+   -- Clauses): "GNAT requires that all alignment clauses specify 0
+   -- or a power of 2, and all default alignments are always a power
+   -- of 2." We also know that {{ required_alignment }} is a power of 2
+   -- via an assertion in gen/models/array.py. Because both sides are
+   -- powers of 2, "T'Alignment <= {{ required_alignment }}" is equivalent to
+   -- "{{ required_alignment }} is a multiple of T'Alignment" -- i.e. our
+   -- aligned local copies satisfy T's alignment requirement and the
+   -- typed overlays in the helpers below are non-erroneous per RM
+   -- 13.3(13/3).
+{% if endianness in ["either", "big"] %}
+   pragma Compile_Time_Error (
+      T'Alignment > {{ required_alignment }},
+      "T'Alignment > static literal ({{ required_alignment }}); update gen/models/array.py"
+   );
+{% endif %}
+{% if endianness in ["either", "little"] %}
+   pragma Compile_Time_Error (
+      T_Le'Alignment > {{ required_alignment }},
+      "T_Le'Alignment > static literal ({{ required_alignment }}); update gen/models/array.py"
+   );
+{% endif %}
+
 {% if endianness in ["either", "big"] %}
    function Valid (
       Bytes : in Serialization.Byte_Array;
@@ -25,78 +87,119 @@ package body {{ name }}.Validation is
       First_Index : in Unconstrained_Index_Type := T'First;
       Last_Index : in Unconstrained_Index_Type := T'Last
    ) return Boolean is
-      -- Overlay the byte array with the packed array for element access.
-      R : T with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
-{% if packed_type_includes %}
-      E_Field : Interfaces.Unsigned_32;
-{% endif %}
-      Count : Interfaces.Unsigned_32 := 0;
-   begin
-      -- Sometimes the valid functions below will NEVER be false, since the type can never be out of range,
-      -- i.e. with an Unsigned_16. If this is the case Ada warns that some code can never be executed. This
-      -- is OK and we want the compiler to delete this code, so ignore the warning.
-      pragma Warnings (Off, "this code can never be executed and has been deleted");
+      use System.Storage_Elements;
 
-      -- Check each element:
+      -- The helper takes a Byte_Array which has no representation
+      -- constraints and overlays T on it locally with an exception
+      -- handler per RM 13.9.2. We walk the elements through R and
+      -- set Errant_Field on the first invalid one.
+      function Valid_Through (Aligned : in Serialization.Byte_Array) return Boolean is
+         -- Alignment of Aligned should be made compatible by called.
+         pragma Assert (
+            To_Integer (Aligned'Address) mod T'Alignment = 0,
+            "Valid_Through: caller passed buffer not aligned to T'Alignment"
+         );
+
+         -- Overlay T. We know alignment is good so ignore warnings.
+         pragma Warnings (Off, "specified address*may be inconsistent with alignment");
+         pragma Warnings (Off, "program execution may be erroneous");
+         R : T with Import, Convention => Ada, Address => Aligned'Address;
+         pragma Warnings (On, "program execution may be erroneous");
+         pragma Warnings (On, "specified address*may be inconsistent with alignment");
+{% if packed_type_includes %}
+         E_Field : Interfaces.Unsigned_32;
+{% endif %}
+         Count : Interfaces.Unsigned_32 := 0;
+      begin
+         -- Sometimes the valid functions below will NEVER be false, since the type can never be out of range,
+         -- i.e. with an Unsigned_16. If this is the case Ada warns that some code can never be executed. This
+         -- is OK and we want the compiler to delete this code, so ignore the warning.
+         pragma Warnings (Off, "this code can never be executed and has been deleted");
+
+         -- Check each element:
 {% if element.skip_validation %}
-      -- Validation turned off for this element type.
+         -- Validation turned off for this element type.
 {% elif element.is_packed_type %}
-      -- Only iterate if the element type can actually be invalid.
-      if not {{ element.type_package }}.Always_Valid then
+         -- Only iterate if the element type can actually be invalid.
+         if not {{ element.type_package }}.Always_Valid then
+            for Idx in First_Index .. Last_Index loop
+               declare
+                  Elem_Bytes : {{ element.type_package }}.Serialization.Byte_Array
+                     with Import, Convention => Ada, Address => R (Idx)'Address;
+               begin
+                  if not {{ element.type_package }}.Validation.Valid (Elem_Bytes, E_Field) then
+                     Errant_Field := Count * {{ element.type_model.num_fields }} + E_Field;
+                     return False;
+                  end if;
+               end;
+               Count := @ + 1;
+            end loop;
+         end if;
+{% else %}
          for Idx in First_Index .. Last_Index loop
-            declare
-               Elem_Bytes : {{ element.type_package }}.Serialization.Byte_Array
-                  with Import, Convention => Ada, Address => R (Idx)'Address;
-            begin
-               if not {{ element.type_package }}.Validation.Valid (Elem_Bytes, E_Field) then
-                  Errant_Field := Count * {{ element.type_model.num_fields }} + E_Field;
+{% if element.format.length %}
+            for Jdx in R (Idx)'Range loop
+               if not R (Idx)(Jdx)'Valid then
+                  Errant_Field := Count + 1;
+                  pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
                   return False;
                end if;
-            end;
-            Count := @ + 1;
-         end loop;
-      end if;
+            end loop;
 {% else %}
-      for Idx in First_Index .. Last_Index loop
-{% if element.format.length %}
-         for Jdx in R (Idx)'Range loop
-            if not R (Idx)(Jdx)'Valid then
+            if not R (Idx)'Valid then
                Errant_Field := Count + 1;
                pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
                return False;
             end if;
+{% endif %}
+            Count := @ + 1;
          end loop;
-{% else %}
-         if not R (Idx)'Valid then
-            Errant_Field := Count + 1;
-            pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
+{% endif %}
+
+         -- Re-enable warning.
+         pragma Warnings (On, "this code can never be executed and has been deleted");
+
+         -- Everything checks out:
+         Errant_Field := 0;
+         return True;
+      exception
+         -- From: http://www.adaic.org/resources/add_content/standards/05aarm/html/AA-13-9-2.html
+         -- The Valid attribute may be used to check the result of calling an
+         -- instance of Unchecked_Conversion (or any other operation that can
+         -- return invalid values). However, an exception handler should also
+         -- be provided because implementations are permitted to raise
+         -- Constraint_Error or Program_Error if they detect the use of an
+         -- invalid representation (see 13.9.1). The handler lives in the
+         -- helper because that's where the per-element 'Valid reads (the
+         -- only realistic raise sites) are.
+         when Constraint_Error =>
+            Errant_Field := 0;
             return False;
-         end if;
+         when Program_Error =>
+            Errant_Field := 0;
+            return False;
+      end Valid_Through;
+   begin
+{% if required_alignment == 1 %}
+      -- Since T has an alignment of 1, this is always safe.
+      return Valid_Through (Bytes);
+{% else %}
+      -- If alignment of bytes is already compatible, then we are safe to
+      -- validate right now.
+      if To_Integer (Bytes'Address) mod T'Alignment = 0 then
+         return Valid_Through (Bytes);
+      else
+         -- The alignment of bytes is not compatible so we need to
+         -- copy bytes to an aligned local copy before validating
+         -- to avoid erroneous behavior.
+         declare
+            Aligned_Bytes : constant Serialization.Byte_Array := Bytes
+               with Alignment => {{ required_alignment }};
+         begin
+            return Valid_Through (Aligned_Bytes);
+         end;
+      end if;
 {% endif %}
-         Count := @ + 1;
-      end loop;
-{% endif %}
-
-      -- Re-enable warning.
-      pragma Warnings (On, "this code can never be executed and has been deleted");
-
-      -- Everything checks out:
-      Errant_Field := 0;
-      return True;
-   exception
-      -- From: http://www.adaic.org/resources/add_content/standards/05aarm/html/AA-13-9-2.html
-      -- The Valid attribute may be used to check the result of calling an
-      -- instance of Unchecked_Conversion (or any other operation that can
-      -- return invalid values). However, an exception handler should also
-      -- be provided because implementations are permitted to raise
-      -- Constraint_Error or Program_Error if they detect the use of an
-      -- invalid representation (see 13.9.1).
-      when Constraint_Error =>
-         Errant_Field := 0;
-         return False;
-      when Program_Error =>
-         Errant_Field := 0;
-         return False;
    end Valid;
 
 {% endif %}
@@ -107,92 +210,154 @@ package body {{ name }}.Validation is
       First_Index : in Unconstrained_Index_Type := T_Le'First;
       Last_Index : in Unconstrained_Index_Type := T_Le'Last
    ) return Boolean is
-      -- Overlay the byte array with the packed array for element access.
-      R : T_Le with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
-{% if packed_type_includes %}
-      E_Field : Interfaces.Unsigned_32;
-{% endif %}
-      Count : Interfaces.Unsigned_32 := 0;
-   begin
-      -- Sometimes the valid functions below will NEVER be false, since the type can never be out of range,
-      -- i.e. with an Unsigned_16. If this is the case Ada warns that some code can never be executed. This
-      -- is OK and we want the compiler to delete this code, so ignore the warning.
-      pragma Warnings (Off, "this code can never be executed and has been deleted");
+      use System.Storage_Elements;
 
-      -- Check each element:
+      -- The helper takes a Byte_Array which has no representation
+      -- constraints and overlays T on it locally with an exception
+      -- handler per RM 13.9.2. We walk the elements through R and
+      -- set Errant_Field on the first invalid one.
+      function Valid_Le_Through (Aligned : in Serialization_Le.Byte_Array) return Boolean is
+         -- Alignment of Aligned should be made compatible by called.
+         pragma Assert (
+            To_Integer (Aligned'Address) mod T_Le'Alignment = 0,
+            "Valid_Le_Through: caller passed buffer not aligned to T_Le'Alignment"
+         );
+
+         -- Overlay T. We know alignment is good so ignore warnings.
+         pragma Warnings (Off, "specified address*may be inconsistent with alignment");
+         pragma Warnings (Off, "program execution may be erroneous");
+         R : T_Le with Import, Convention => Ada, Address => Aligned'Address;
+         pragma Warnings (On, "program execution may be erroneous");
+         pragma Warnings (On, "specified address*may be inconsistent with alignment");
+{% if packed_type_includes %}
+         E_Field : Interfaces.Unsigned_32;
+{% endif %}
+         Count : Interfaces.Unsigned_32 := 0;
+      begin
+         -- Sometimes the valid functions below will NEVER be false, since the type can never be out of range,
+         -- i.e. with an Unsigned_16. If this is the case Ada warns that some code can never be executed. This
+         -- is OK and we want the compiler to delete this code, so ignore the warning.
+         pragma Warnings (Off, "this code can never be executed and has been deleted");
+
+         -- Check each element:
 {% if element.skip_validation %}
-      -- Validation turned off for this element type.
+         -- Validation turned off for this element type.
 {% elif element.is_packed_type %}
-      -- Only iterate if the element type can actually be invalid.
-      if not {{ element.type_package }}.Always_Valid then
+         -- Only iterate if the element type can actually be invalid.
+         if not {{ element.type_package }}.Always_Valid then
+            for Idx in First_Index .. Last_Index loop
+               declare
+                  Elem_Bytes : {{ element.type_package }}.Serialization_Le.Byte_Array
+                     with Import, Convention => Ada, Address => R (Idx)'Address;
+               begin
+                  if not {{ element.type_package }}.Validation.Valid_Le (Elem_Bytes, E_Field) then
+                     Errant_Field := Count * {{ element.type_model.num_fields }} + E_Field;
+                     return False;
+                  end if;
+               end;
+               Count := @ + 1;
+            end loop;
+         end if;
+{% else %}
          for Idx in First_Index .. Last_Index loop
-            declare
-               Elem_Bytes : {{ element.type_package }}.Serialization_Le.Byte_Array
-                  with Import, Convention => Ada, Address => R (Idx)'Address;
-            begin
-               if not {{ element.type_package }}.Validation.Valid_Le (Elem_Bytes, E_Field) then
-                  Errant_Field := Count * {{ element.type_model.num_fields }} + E_Field;
+{% if element.format.length %}
+            for Jdx in R (Idx)'Range loop
+               if not R (Idx)(Jdx)'Valid then
+                  Errant_Field := Count + 1;
+                  pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
                   return False;
                end if;
-            end;
-            Count := @ + 1;
-         end loop;
-      end if;
+            end loop;
 {% else %}
-      for Idx in First_Index .. Last_Index loop
-{% if element.format.length %}
-         for Jdx in R (Idx)'Range loop
-            if not R (Idx)(Jdx)'Valid then
+            if not R (Idx)'Valid then
                Errant_Field := Count + 1;
                pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
                return False;
             end if;
+{% endif %}
+            Count := @ + 1;
          end loop;
-{% else %}
-         if not R (Idx)'Valid then
-            Errant_Field := Count + 1;
-            pragma Annotate (GNATSAS, Intentional, "dead code", "some array elements may not be bit-constrained and thus will always be valid");
+{% endif %}
+
+         -- Re-enable warning.
+         pragma Warnings (On, "this code can never be executed and has been deleted");
+
+         -- Everything checks out:
+         Errant_Field := 0;
+         return True;
+      exception
+         -- From: http://www.adaic.org/resources/add_content/standards/05aarm/html/AA-13-9-2.html
+         -- The Valid attribute may be used to check the result of calling an
+         -- instance of Unchecked_Conversion (or any other operation that can
+         -- return invalid values). However, an exception handler should also
+         -- be provided because implementations are permitted to raise
+         -- Constraint_Error or Program_Error if they detect the use of an
+         -- invalid representation (see 13.9.1). The handler lives in the
+         -- helper because that's where the per-element 'Valid reads (the
+         -- only realistic raise sites) are.
+         when Constraint_Error =>
+            Errant_Field := 0;
             return False;
-         end if;
+         when Program_Error =>
+            Errant_Field := 0;
+            return False;
+      end Valid_Le_Through;
+   begin
+{% if required_alignment == 1 %}
+      -- Since T_Le has an alignment of 1, this is always safe.
+      return Valid_Le_Through (Bytes);
+{% else %}
+      -- If alignment of bytes is already compatible, then we are safe to
+      -- validate right now.
+      if To_Integer (Bytes'Address) mod T_Le'Alignment = 0 then
+         return Valid_Le_Through (Bytes);
+      else
+         -- The alignment of bytes is not compatible so we need to
+         -- copy bytes to an aligned local copy before validating
+         -- to avoid erroneous behavior.
+         declare
+            Aligned_Bytes : constant Serialization_Le.Byte_Array := Bytes
+               with Alignment => {{ required_alignment }};
+         begin
+            return Valid_Le_Through (Aligned_Bytes);
+         end;
+      end if;
 {% endif %}
-         Count := @ + 1;
-      end loop;
-{% endif %}
-
-      -- Re-enable warning.
-      pragma Warnings (On, "this code can never be executed and has been deleted");
-
-      -- Everything checks out:
-      Errant_Field := 0;
-      return True;
-   exception
-      -- From: http://www.adaic.org/resources/add_content/standards/05aarm/html/AA-13-9-2.html
-      -- The Valid attribute may be used to check the result of calling an
-      -- instance of Unchecked_Conversion (or any other operation that can
-      -- return invalid values). However, an exception handler should also
-      -- be provided because implementations are permitted to raise
-      -- Constraint_Error or Program_Error if they detect the use of an
-      -- invalid representation (see 13.9.1).
-      when Constraint_Error =>
-         Errant_Field := 0;
-         return False;
-      when Program_Error =>
-         Errant_Field := 0;
-         return False;
    end Valid_Le;
 
 {% endif %}
 {% if endianness in ["either", "big"] %}
    function Get_Field (Bytes : in Serialization.Byte_Array; Field : in Interfaces.Unsigned_32) return Basic_Types.Poly_Type is
-      -- Overlay the byte array with the packed array for element access.
-      Src : T with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
 {% if element.is_packed_type %}
       Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type ((Field - 1) / {{ element.type_model.num_fields }});
       Remainder : Unsigned_32 := 0;
       To_Return : Basic_Types.Poly_Type;
+      Element_Stride_Bytes : constant Natural := {{ element.type_package }}.Size_In_Bytes;
+      Slice_Start : constant Natural := Bytes'First + Natural (Idx - Constrained_Index_Type'First) * Element_Stride_Bytes;
+{% elif (element.size % 8) == 0 %}
+      use Byte_Array_Util;
+      To_Return : Basic_Types.Poly_Type := [others => 0];
+      -- Copy only the bytes for the one element into an aligned local
+      -- then read the value through an overlay. This is cheaper than
+      -- copying the whole Bytes buffer just to read one element. The
+      -- slice's alignment must satisfy T_Unconstrained's alignment;
+      -- the Compile_Time_Error below verifies our static literal does.
+      Slice_Start : constant Natural := Bytes'First + (Natural (Field) - 1) * Element_Size_In_Bytes;
+      pragma Compile_Time_Error (T_Unconstrained'Alignment > {{ required_alignment }},
+         "T_Unconstrained'Alignment > static literal ({{ required_alignment }}); update gen/models/array.py");
+      Slice : Basic_Types.Byte_Array (0 .. Element_Size_In_Bytes - 1) :=
+         Bytes (Slice_Start .. Slice_Start + Element_Size_In_Bytes - 1)
+         with Alignment => {{ required_alignment }};
+      Src : T_Unconstrained (Constrained_Index_Type'First .. Constrained_Index_Type'First)
+         with Import, Convention => Ada, Address => Slice'Address;
 {% else %}
       use Byte_Array_Util;
       To_Return : Basic_Types.Poly_Type := [others => 0];
+      -- For sub-byte type, for safety, we need to copy the full
+      -- Bytes into an aligned local matching T'Alignment.
+      Aligned_Bytes : constant Serialization.Byte_Array := Bytes
+         with Alignment => {{ required_alignment }};
+      Src : T with Import, Convention => Ada, Address => Aligned_Bytes'Address;
 {% endif %}
    begin
 {% if element.is_packed_type %}
@@ -201,7 +366,7 @@ package body {{ name }}.Validation is
       end if;
       declare
          Elem_Bytes : {{ element.type_package }}.Serialization.Byte_Array
-            with Import, Convention => Ada, Address => Src (Idx)'Address;
+            with Import, Convention => Ada, Address => Bytes (Slice_Start)'Address;
       begin
          To_Return := {{ element.type_package }}.Validation.Get_Field (Elem_Bytes, Remainder);
       end;
@@ -211,7 +376,11 @@ package body {{ name }}.Validation is
          -- and we know this, so suppresss any checks by the compiler for this copy.
          pragma Suppress (Range_Check);
          pragma Suppress (Overflow_Check);
+{% if (element.size % 8) == 0 %}
+         Var : constant {{ element.type }} := Src (Constrained_Index_Type'First);
+{% else %}
          Var : constant {{ element.type }} := Src (Src'First + Unconstrained_Index_Type (Field) - 1);
+{% endif %}
          pragma Unsuppress (Range_Check);
          pragma Unsuppress (Overflow_Check);
          -- Now overlay the var with a byte array before copying it into the polytype.
@@ -236,15 +405,36 @@ package body {{ name }}.Validation is
 {% endif %}
 {% if endianness in ["either", "little"] %}
    function Get_Field_Le (Bytes : in Serialization_Le.Byte_Array; Field : in Interfaces.Unsigned_32) return Basic_Types.Poly_Type is
-      -- Overlay the byte array with the packed array for element access.
-      Src : T_Le with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
 {% if element.is_packed_type %}
       Idx : constant Constrained_Index_Type := Constrained_Index_Type'First + Unconstrained_Index_Type ((Field - 1) / {{ element.type_model.num_fields }});
       Remainder : Unsigned_32 := 0;
       To_Return : Basic_Types.Poly_Type;
+      Element_Stride_Bytes : constant Natural := {{ element.type_package }}.Size_In_Bytes;
+      Slice_Start : constant Natural := Bytes'First + Natural (Idx - Constrained_Index_Type'First) * Element_Stride_Bytes;
+{% elif (element.size % 8) == 0 %}
+      use Byte_Array_Util;
+      To_Return : Basic_Types.Poly_Type := [others => 0];
+      -- Copy only the bytes for the one element into an aligned local
+      -- then read the value through an overlay. This is cheaper than
+      -- copying the whole Bytes buffer just to read one element. The
+      -- slice's alignment must satisfy T_Le_Unconstrained's alignment;
+      -- the Compile_Time_Error below verifies our static literal does.
+      Slice_Start : constant Natural := Bytes'First + (Natural (Field) - 1) * Element_Size_In_Bytes;
+      pragma Compile_Time_Error (T_Le_Unconstrained'Alignment > {{ required_alignment }},
+         "T_Le_Unconstrained'Alignment > static literal ({{ required_alignment }}); update gen/models/array.py");
+      Slice : Basic_Types.Byte_Array (0 .. Element_Size_In_Bytes - 1) :=
+         Bytes (Slice_Start .. Slice_Start + Element_Size_In_Bytes - 1)
+         with Alignment => {{ required_alignment }};
+      Src : T_Le_Unconstrained (Constrained_Index_Type'First .. Constrained_Index_Type'First)
+         with Import, Convention => Ada, Address => Slice'Address;
 {% else %}
       use Byte_Array_Util;
       To_Return : Basic_Types.Poly_Type := [others => 0];
+      -- For sub-byte type, for safety, we need to copy the full
+      -- Bytes into an aligned local matching T_Le'Alignment.
+      Aligned_Bytes : constant Serialization_Le.Byte_Array := Bytes
+         with Alignment => {{ required_alignment }};
+      Src : T_Le with Import, Convention => Ada, Address => Aligned_Bytes'Address;
 {% endif %}
    begin
 {% if element.is_packed_type %}
@@ -253,7 +443,7 @@ package body {{ name }}.Validation is
       end if;
       declare
          Elem_Bytes : {{ element.type_package }}.Serialization_Le.Byte_Array
-            with Import, Convention => Ada, Address => Src (Idx)'Address;
+            with Import, Convention => Ada, Address => Bytes (Slice_Start)'Address;
       begin
          To_Return := {{ element.type_package }}.Validation.Get_Field_Le (Elem_Bytes, Remainder);
       end;
@@ -263,7 +453,11 @@ package body {{ name }}.Validation is
          -- and we know this, so suppresss any checks by the compiler for this copy.
          pragma Suppress (Range_Check);
          pragma Suppress (Overflow_Check);
+{% if (element.size % 8) == 0 %}
+         Var : constant {{ element.type }} := Src (Constrained_Index_Type'First);
+{% else %}
          Var : constant {{ element.type }} := Src (Src'First + Unconstrained_Index_Type (Field) - 1);
+{% endif %}
          pragma Unsuppress (Range_Check);
          pragma Unsuppress (Overflow_Check);
          -- Now overlay the var with a byte array before copying it into the polytype.

--- a/gen/templates/record/name-validation.adb
+++ b/gen/templates/record/name-validation.adb
@@ -18,11 +18,13 @@ with {{ include }}.Validation;
 package body {{ name }}.Validation is
 
 {% if endianness in ["either", "big"] %}
-   pragma Warnings (Off, "formal parameter ""Bytes"" is not referenced");
    function Valid (Bytes : in Serialization.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean is
-   pragma Warnings (On, "formal parameter ""Bytes"" is not referenced");
-      -- Overlay the byte array with the packed record for field access.
-      R : T with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
+      -- Direct overlay onto Bytes is alignment-safe regardless of
+      -- Bytes' runtime address: T is a bit-packed record with
+      -- Alignment => 1, which matches Byte_Array's natural alignment.
+      pragma Compile_Time_Error (T'Alignment /= 1,
+         "T'Alignment /= 1; the direct-overlay assumption in gen/templates/record/name-validation.adb is broken");
+      R : T with Import, Convention => Ada, Address => Bytes'Address;
 {% for include in variable_length_type_includes %}
 {% if include not in ["Interfaces"] %}
       use {{ include }};
@@ -169,11 +171,13 @@ package body {{ name }}.Validation is
 
 {% endif %}
 {% if endianness in ["either", "little"] %}
-   pragma Warnings (Off, "formal parameter ""Bytes"" is not referenced");
    function Valid_Le (Bytes : in Serialization_Le.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean is
-   pragma Warnings (On, "formal parameter ""Bytes"" is not referenced");
-      -- Overlay the byte array with the packed record for field access.
-      R : T_Le with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
+      -- Direct overlay onto Bytes is alignment-safe regardless of
+      -- Bytes' runtime address: T_Le is a bit-packed record with
+      -- Alignment => 1, which matches Byte_Array's natural alignment.
+      pragma Compile_Time_Error (T_Le'Alignment /= 1,
+         "T_Le'Alignment /= 1; the direct-overlay assumption in gen/templates/record/name-validation.adb is broken");
+      R : T_Le with Import, Convention => Ada, Address => Bytes'Address;
 {% for include in variable_length_type_includes %}
 {% if include not in ["Interfaces"] %}
       use {{ include }};
@@ -325,7 +329,12 @@ package body {{ name }}.Validation is
       use Byte_Array_Util;
 {% endif %}
       -- Overlay the byte array with the packed record for field access.
-      Src : T with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
+      -- Direct overlay is alignment-safe because T is a bit-packed
+      -- record with Alignment => 1, which matches Byte_Array's
+      -- natural alignment.
+      pragma Compile_Time_Error (T'Alignment /= 1,
+         "T'Alignment /= 1; the direct-overlay assumption in gen/templates/record/name-validation.adb is broken");
+      Src : T with Import, Convention => Ada, Address => Bytes'Address;
       To_Return : Basic_Types.Poly_Type := [others => 0];
    begin
       case Field is
@@ -379,7 +388,12 @@ package body {{ name }}.Validation is
       use Byte_Array_Util;
 {% endif %}
       -- Overlay the byte array with the packed record for field access.
-      Src : T_Le with Import, Convention => Ada, Address => Bytes'Address, Alignment => 1;
+      -- Direct overlay is alignment-safe because T_Le is a bit-packed
+      -- record with Alignment => 1, which matches Byte_Array's
+      -- natural alignment.
+      pragma Compile_Time_Error (T_Le'Alignment /= 1,
+         "T_Le'Alignment /= 1; the direct-overlay assumption in gen/templates/record/name-validation.adb is broken");
+      Src : T_Le with Import, Convention => Ada, Address => Bytes'Address;
       To_Return : Basic_Types.Poly_Type := [others => 0];
    begin
       case Field is

--- a/gen/test/arrays/nested_float_array.array.yaml
+++ b/gen/test/arrays/nested_float_array.array.yaml
@@ -1,0 +1,12 @@
+---
+description: |
+  Packed array whose element is itself a packed array of Short_Float.
+  Exercises the byte-aligned-element path in the validation autocode
+  for a non-pow2 element byte size: each Packed_F32x3 element is 12
+  bytes, so GNAT picks T'Alignment = 4 (greatest pow2 factor of 12)
+  rather than collapsing to 1 like it would for a packed-record
+  element. Regressions in gen/models/array.py's required_alignment
+  computation will fire the parallel pragma Compile_Time_Error in
+  name-validation.adb.
+type: Packed_F32x3.T
+length: 2

--- a/gen/test/arrays/nested_unaligned_array.array.yaml
+++ b/gen/test/arrays/nested_unaligned_array.array.yaml
@@ -1,0 +1,10 @@
+---
+description: |
+  Outer packed array whose element is the sub-byte Unaligned_Array.T
+  (8 x 10-bit Short_Int -> total 80 bits, 10 bytes). Inner's
+  T'Alignment is 16 (next pow2 of 10) but GNAT does NOT propagate
+  that to the outer -- it picks the greatest pow2 factor of element
+  byte size (10), which is 2. Adding this case prevents a regression
+  where required_alignment naively reuses the inner array's value.
+type: Unaligned_Array.T
+length: 2

--- a/gen/test/arrays/test/test.adb
+++ b/gen/test/arrays/test/test.adb
@@ -15,6 +15,11 @@ with Complex_Array_Le.C; use Complex_Array_Le.C;
 with Eight_Bit_Type_Array.Validation;
 with Unaligned_Array.Validation;
 with Enum_Array.Validation;
+with Float_Array.Validation;
+with Complex_Float_Array.Validation;
+with Complex_Array_Le.Validation;
+with Float_Array;
+with Complex_Float_Array;
 with Simple_Array.Assertion; use Simple_Array.Assertion;
 with Float_Array.Assertion; use Float_Array.Assertion;
 with Complex_Array.Assertion; use Complex_Array.Assertion;
@@ -579,5 +584,221 @@ begin
       end loop;
       Put_Line ("passed.");
    end;
+   Put_Line ("");
+
+   -- Misalignment-resilience tests for Validation autocode
+   --
+   -- Per Ada 2022 RM 13.3(13/3):
+   --   "If an Address is specified, it is the programmer's
+   --   responsibility to ensure that the address is valid and
+   --   appropriate for the entity and its use; otherwise, program
+   --   execution is erroneous."
+   --   (http://www.ada-auth.org/standards/22rm/html/RM-13-3.html)
+   --
+   -- Adamant's Validation autocode keeps us out of the erroneous case
+   -- for packed-array types whose elements are byte-aligned
+   -- (Short_Float, Unsigned_32, etc.) by one of three strategies,
+   -- depending on call site:
+   --   - direct overlay when Bytes' address already satisfies
+   --     T'Alignment (Valid fast path)
+   --   - aligned local copy when it doesn't (Valid slow path)
+   --   - per-field slice-copy in Get_Field for byte-aligned elements
+   Put_Line ("Validation misalignment tests: ");
+   declare
+      --  Big buffer, explicitly 4-aligned. Slicing it at byte offsets
+      --  0..3 gives known-aligned and known-misaligned start addresses
+      --  for the embedded Serialization.Byte_Array overlays below.
+      --  Sized to comfortably hold the largest array exercised here
+      --  (Complex_Float_Array, ~325 bytes) plus 4 bytes of slack for
+      --  the offset.
+      Big : aliased Basic_Types.Byte_Array (0 .. 511) := [others => 0];
+      for Big'Alignment use 4;
+
+      -- Helper: produce a Boolean image that fits in a single token.
+      function B_Img (V : Boolean) return String is (if V then "TRUE" else "FALSE");
+   begin
+      -- Float_Array: 12 x Short_Float, F32 -- byte-aligned 4-byte
+      -- elements.
+      Put ("  Float_Array @ each offset 0..3: ");
+      declare
+         -- All elements 1.5 (0x3FC00000 BE). Valid floats.
+         F_Bytes : constant Float_Array.Serialization.Byte_Array :=
+            Float_Array.Serialization.To_Byte_Array ([others => 1.5]);
+      begin
+         for Offset in 0 .. 3 loop
+            -- Copy known bytes to the buffer at this byte offset.
+            Big (Offset .. Offset + F_Bytes'Length - 1) := F_Bytes;
+            declare
+               -- Overlay the Serialization.Byte_Array view at the
+               -- offset. Runtime address depends on Offset:
+               --   Offset 0 -> 4-aligned (Big is 4-aligned)
+               --   Offset 1, 2, 3 -> misaligned by that many bytes.
+               Slice : Float_Array.Serialization.Byte_Array
+                  with Import, Convention => Ada,
+                       Address => Big (Offset)'Address;
+               Ignore_Errant : Unsigned_32;
+               Ok : constant Boolean := Float_Array.Validation.Valid (Slice, Ignore_Errant);
+            begin
+               pragma Assert (Ok, "Float_Array.Valid returned False at offset" & Offset'Image);
+               -- Verify Get_Field reads the correct bytes for each
+               -- field index regardless of alignment.
+               for Idx in 1 .. Float_Array.Length loop
+                  declare
+                     Got : constant Basic_Types.Poly_Type :=
+                        Float_Array.Validation.Get_Field (Slice, Unsigned_32 (Idx));
+                  begin
+                     -- Short_Float 1.5 widens to 0x3FC00000 in the
+                     -- Poly_Type's native byte order (LE on host),
+                     -- so the polytype tail bytes should be
+                     -- [00 00 00 00 00 00 C0 3F].
+                     pragma Assert (Got = [0, 0, 0, 0, 0, 0, 16#C0#, 16#3F#],
+                                    "Float_Array.Get_Field wrong at offset" & Offset'Image
+                                    & " idx" & Idx'Image);
+                  end;
+               end loop;
+            end;
+            -- Zero the buffer back out for the next offset's copy.
+            Big (Offset .. Offset + F_Bytes'Length - 1) := [others => 0];
+         end loop;
+      end;
+      Put_Line ("ok.");
+
+      -- Simple_Array: 17 x Short_Int (range 1..999), U16 -- byte-
+      -- aligned 2-byte elements. Validates that the runtime check
+      -- works when T'Alignment is 4 (Short_Int's underlying type)
+      -- but element stride is 2.
+      Put ("  Simple_Array (valid + invalid) @ each offset 0..3: ");
+      declare
+         Valid_Bytes : constant Simple_Array.Serialization.Byte_Array :=
+            Simple_Array.Serialization.To_Byte_Array ([others => 5]);
+         -- Element 2 is 0x0001 = 1 (valid), element 3 is 0x01FF = 511
+         -- (valid), element ... actually craft byte 0,1=0,1 (1,
+         -- valid) and bytes 2,3=0,1 (still 1)... we want one invalid
+         -- element. Field 3 byte-pattern 0xFFFF = 65535, out of
+         -- range 1..999.
+         Invalid_Bytes : Simple_Array.Serialization.Byte_Array :=
+            Valid_Bytes;
+      begin
+         -- Make element index 2 (1-indexed: field 3) invalid:
+         -- bytes [4..5] of the buffer hold the third element (16-bit BE).
+         Invalid_Bytes (4) := 16#FF#;
+         Invalid_Bytes (5) := 16#FF#;
+
+         for Offset in 0 .. 3 loop
+            -- Valid path
+            Big (Offset .. Offset + Valid_Bytes'Length - 1) := Valid_Bytes;
+            declare
+               Slice : Simple_Array.Serialization.Byte_Array
+                  with Import, Convention => Ada, Address => Big (Offset)'Address;
+               Ignore_Errant : Unsigned_32;
+            begin
+               pragma Assert (Simple_Array.Validation.Valid (Slice, Ignore_Errant),
+                              "Simple_Array.Valid (valid) at offset" & Offset'Image);
+            end;
+            Big (Offset .. Offset + Valid_Bytes'Length - 1) := [others => 0];
+
+            -- Invalid path
+            Big (Offset .. Offset + Invalid_Bytes'Length - 1) := Invalid_Bytes;
+            declare
+               Slice : Simple_Array.Serialization.Byte_Array
+                  with Import, Convention => Ada, Address => Big (Offset)'Address;
+               Errant : Unsigned_32 := 0;
+               Ok : constant Boolean := Simple_Array.Validation.Valid (Slice, Errant);
+            begin
+               pragma Assert (not Ok, "Simple_Array.Valid (invalid) at offset" & Offset'Image
+                              & " returned " & B_Img (Ok));
+               pragma Assert (Errant = 3, "Simple_Array errant_field wrong at offset"
+                              & Offset'Image & " got " & Errant'Image);
+               -- Get_Field on the offending index. Var is Short_Int
+               -- (Natural, 32-bit) holding 0xFFFF; on a little-endian
+               -- host its memory bytes are [0xFF, 0xFF, 0x00, 0x00].
+               -- Safe_Right_Copy puts Src into the last N positions of
+               -- Dest, so Poly_Type[4..7] = those 4 bytes.
+               pragma Assert (Simple_Array.Validation.Get_Field (Slice, 3)
+                              = [0, 0, 0, 0, 16#FF#, 16#FF#, 0, 0],
+                              "Simple_Array.Get_Field wrong at offset" & Offset'Image);
+            end;
+            Big (Offset .. Offset + Invalid_Bytes'Length - 1) := [others => 0];
+         end loop;
+      end;
+      Put_Line ("ok.");
+
+      -- Unaligned_Array: 8 x Short_Int (range 0..999), U10 -- sub-
+      -- byte-aligned (10-bit element). The template uses the direct
+      -- overlay path here (no slice-copy, no runtime check needed
+      -- since GNAT bit-extracts these). This test ensures that path
+      -- still produces correct results across alignment offsets.
+      Put ("  Unaligned_Array @ each offset 0..3: ");
+      declare
+         U_Valid : constant Unaligned_Array.Serialization.Byte_Array :=
+            Unaligned_Array.Serialization.To_Byte_Array ([others => 7]);
+      begin
+         for Offset in 0 .. 3 loop
+            Big (Offset .. Offset + U_Valid'Length - 1) := U_Valid;
+            declare
+               Slice : Unaligned_Array.Serialization.Byte_Array
+                  with Import, Convention => Ada, Address => Big (Offset)'Address;
+               Ignore_Errant : Unsigned_32;
+            begin
+               pragma Assert (Unaligned_Array.Validation.Valid (Slice, Ignore_Errant),
+                              "Unaligned_Array.Valid (valid) at offset" & Offset'Image);
+            end;
+            Big (Offset .. Offset + U_Valid'Length - 1) := [others => 0];
+         end loop;
+      end;
+      Put_Line ("ok.");
+
+      -- Complex_Float_Array: array of records-with-floats. Exercises
+      -- the packed-element delegation path (R(Idx)'Address -> inner
+      -- Validation.Valid) with a record element whose own validation
+      -- reads multi-byte fields. This is the chain the rate_control
+      -- bug originally surfaced through (record validation delegated
+      -- to inner array validation on a misaligned slice).
+      Put ("  Complex_Float_Array @ each offset 0..3: ");
+      declare
+         Cf_Bytes : constant Complex_Float_Array.Serialization.Byte_Array :=
+            Complex_Float_Array.Serialization.To_Byte_Array (
+               [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345))]);
+      begin
+         for Offset in 0 .. 3 loop
+            Big (Offset .. Offset + Cf_Bytes'Length - 1) := Cf_Bytes;
+            declare
+               Slice : Complex_Float_Array.Serialization.Byte_Array
+                  with Import, Convention => Ada, Address => Big (Offset)'Address;
+               Ignore_Errant : Unsigned_32;
+            begin
+               pragma Assert (Complex_Float_Array.Validation.Valid (Slice, Ignore_Errant),
+                              "Complex_Float_Array.Valid at offset" & Offset'Image);
+            end;
+            Big (Offset .. Offset + Cf_Bytes'Length - 1) := [others => 0];
+         end loop;
+      end;
+      Put_Line ("ok.");
+
+      -- Complex_Array_Le: little-endian record-element array.
+      -- Exercises the LE validation path (Valid_Le / Get_Field_Le)
+      -- with the same misaligned-slice pattern.
+      Put ("  Complex_Array_Le @ each offset 0..3: ");
+      declare
+         Cl_Bytes : constant Complex_Array_Le.Serialization_Le.Byte_Array :=
+            Complex_Array_Le.Serialization_Le.To_Byte_Array (
+               [others => (One => 0, Two => 19, Three => 5)]);
+      begin
+         for Offset in 0 .. 3 loop
+            Big (Offset .. Offset + Cl_Bytes'Length - 1) := Cl_Bytes;
+            declare
+               Slice : Complex_Array_Le.Serialization_Le.Byte_Array
+                  with Import, Convention => Ada, Address => Big (Offset)'Address;
+               Ignore_Errant : Unsigned_32;
+            begin
+               pragma Assert (Complex_Array_Le.Validation.Valid_Le (Slice, Ignore_Errant),
+                              "Complex_Array_Le.Valid_Le at offset" & Offset'Image);
+            end;
+            Big (Offset .. Offset + Cl_Bytes'Length - 1) := [others => 0];
+         end loop;
+      end;
+      Put_Line ("ok.");
+   end;
+   Put_Line ("passed.");
    Put_Line ("");
 end Test;

--- a/gen/test/arrays/test_misalign/env.py
+++ b/gen/test/arrays/test_misalign/env.py
@@ -1,0 +1,22 @@
+from environments import test, modify_build_path  # noqa: F401
+import os
+
+this_dir = os.path.dirname(os.path.realpath(__file__))
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+        # Pull in Packed_F64x3 from src/types/packed_arrays so we can
+        # exercise the 64-bit byte-aligned-primitive runtime path.
+        os.path.realpath(
+            os.path.join(
+                this_dir,
+                ".." + os.sep + ".." + os.sep + ".."
+                + os.sep + "src" + os.sep + "types" + os.sep + "packed_arrays",
+            )
+        ),
+    ]
+)

--- a/gen/test/arrays/test_misalign/test.adb
+++ b/gen/test/arrays/test_misalign/test.adb
@@ -1,0 +1,404 @@
+--------------------------------------------------------------------------------
+-- Misalignment-resilience test for the packed-array Validation autocode,
+-- structured specifically to be runnable on cross-compiled bareboard
+-- targets, which is the real point of this file. Alignment-related bugs
+-- in the autocode behave very differently per host:
+--
+--   * x86_64 Linux silently handles misaligned typed loads, so the same
+--     bug that traps on bareboard reads "correctly" on the host. Linux
+--     tests will pass even when the autocode is alignment-fragile -- so
+--     a host-only regression test cannot catch this class of bug.
+--
+--   * Cross embedded targets  trap on misaligned
+--     `flw` / `lhu` / etc., or return garbage bits depending on the
+--     core. Either is a valid "erroneous" outcome per RM 13.3(13/3),
+--     and either makes this test fail loudly.
+--
+-- Why this lives in its own directory rather than as a section of the
+-- companion test/test.adb:
+--
+--   1. test/test.adb pulls in heavy string-formatting plumbing
+--      (String_Util.To_Tuple_String, Poly_Type formatters, etc.) that
+--      overflow the embedded runtime's secondary stack on bareboard.
+--      This file is sized to fit.
+--
+--   2. The pattern is intentionally different from the rest of gen/test:
+--      no `pragma Assert` (suppressible by `pragma Suppress
+--      (Assertion_Check)` and ignored under `Assertion_Policy => Ignore`
+--      profiles) -- instead a `Check` helper procedure that always
+--      runs and increments a counter. The summary at the end is
+--      AUnit-text-reporter-format ("Total Tests Run: N / Failed
+--      Assertions: 0 / Unexpected Errors: 0") so the cross-test renode
+--      runner can scrape pass/fail without parsing Put_Line transcripts.
+--
+-- Concretely the test exercises Validation.Valid / Get_Field (and the
+-- Le variants) at every byte alignment offset 0..N from an aligned
+-- base. A regression that re-introduces a typed view overlaid directly
+-- on a possibly-misaligned address either traps on bareboard or returns
+-- garbage that fails the value comparisons. Per RM 13.3(13/3):
+--
+--   "If an Address is specified, it is the programmer's responsibility
+--   to ensure that the address is valid and appropriate for the entity
+--   and its use; otherwise, program execution is erroneous."
+--   (http://www.ada-auth.org/standards/22rm/html/RM-13-3.html)
+
+with Ada.Text_IO; use Ada.Text_IO;
+with Float_Array;
+with Float_Array.Validation;
+with Simple_Array;
+with Simple_Array.Validation;
+with Unaligned_Array;
+with Unaligned_Array.Validation;
+with Complex_Float_Array;
+with Complex_Float_Array.Validation;
+with Complex_Array_Le;
+with Complex_Array_Le.Validation;
+with Packed_F64x3;
+with Packed_F64x3.Validation;
+with Nested_Float_Array;
+with Nested_Float_Array.Validation;
+with Nested_Unaligned_Array;
+with Nested_Unaligned_Array.Validation;
+with Basic_Types; use Basic_Types;
+with Interfaces; use Interfaces;
+
+procedure Test is
+   --  Big buffer, explicitly 8-aligned (we exercise an 8-byte primitive
+   --  array, so 8 is the largest natural alignment we need any subtest
+   --  to start from). Slicing at byte offsets 0..3 gives known-aligned
+   --  and known-misaligned start addresses.
+   Big : aliased Basic_Types.Byte_Array (0 .. 511) := [others => 0];
+   for Big'Alignment use 8;
+
+   --  Pass/fail accounting. A failure prints a message and bumps Failed
+   --  but does not raise -- we want to see all failures, not just the
+   --  first. The summary at the end is in AUnit's text-reporter format
+   --  so the cross runner picks it up.
+   Total : Natural := 0;
+   Failed : Natural := 0;
+
+   procedure Check (Cond : Boolean; Message : String) is
+   begin
+      Total := Total + 1;
+      if not Cond then
+         Failed := Failed + 1;
+         Put_Line ("  FAIL: " & Message);
+      end if;
+   end Check;
+begin
+   Put_Line ("Validation misalignment tests:");
+
+   --------------------------------------------------------------------
+   -- Float_Array -- 12 x Short_Float, F32. Byte-aligned 4-byte
+   -- elements: this is the original cross-test bug shape.
+   -- BE + LE.
+   --------------------------------------------------------------------
+   declare
+      F_Bytes : constant Float_Array.Serialization.Byte_Array :=
+         Float_Array.Serialization.To_Byte_Array ([others => 1.5]);
+      F_Bytes_Le : constant Float_Array.Serialization_Le.Byte_Array :=
+         Float_Array.Serialization_Le.To_Byte_Array ([others => 1.5]);
+   begin
+      for Offset in 0 .. 3 loop
+         -- BE: Valid + Get_Field
+         Big (Offset .. Offset + F_Bytes'Length - 1) := F_Bytes;
+         declare
+            Slice : Float_Array.Serialization.Byte_Array
+               with Import, Convention => Ada,
+                    Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+            Ok : constant Boolean := Float_Array.Validation.Valid (Slice, Ignore_Errant);
+         begin
+            Check (Ok, "Float_Array.Valid offset" & Offset'Image);
+            for Idx in 1 .. Float_Array.Length loop
+               declare
+                  Got : constant Basic_Types.Poly_Type :=
+                     Float_Array.Validation.Get_Field (Slice, Unsigned_32 (Idx));
+               begin
+                  Check (Got = [0, 0, 0, 0, 0, 0, 16#C0#, 16#3F#],
+                         "Float_Array.Get_Field offset" & Offset'Image
+                         & " idx" & Idx'Image);
+               end;
+            end loop;
+         end;
+         Big (Offset .. Offset + F_Bytes'Length - 1) := [others => 0];
+
+         -- LE: Valid_Le + Get_Field_Le
+         Big (Offset .. Offset + F_Bytes_Le'Length - 1) := F_Bytes_Le;
+         declare
+            Slice : Float_Array.Serialization_Le.Byte_Array
+               with Import, Convention => Ada,
+                    Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+            Ok : constant Boolean := Float_Array.Validation.Valid_Le (Slice, Ignore_Errant);
+         begin
+            Check (Ok, "Float_Array.Valid_Le offset" & Offset'Image);
+            for Idx in 1 .. Float_Array.Length loop
+               declare
+                  Got : constant Basic_Types.Poly_Type :=
+                     Float_Array.Validation.Get_Field_Le (Slice, Unsigned_32 (Idx));
+               begin
+                  Check (Got = [0, 0, 0, 0, 0, 0, 16#C0#, 16#3F#],
+                         "Float_Array.Get_Field_Le offset" & Offset'Image
+                         & " idx" & Idx'Image);
+               end;
+            end loop;
+         end;
+         Big (Offset .. Offset + F_Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Packed_F64x3 -- 3 x Long_Float, F64. Byte-aligned 8-byte
+   -- elements: required_alignment=8 path that the slow-path 8-byte
+   -- copy must satisfy. BE + LE.
+   --------------------------------------------------------------------
+   declare
+      D_Bytes : constant Packed_F64x3.Serialization.Byte_Array :=
+         Packed_F64x3.Serialization.To_Byte_Array ([others => 1.5]);
+      D_Bytes_Le : constant Packed_F64x3.Serialization_Le.Byte_Array :=
+         Packed_F64x3.Serialization_Le.To_Byte_Array ([others => 1.5]);
+   begin
+      for Offset in 0 .. 7 loop
+         -- BE
+         Big (Offset .. Offset + D_Bytes'Length - 1) := D_Bytes;
+         declare
+            Slice : Packed_F64x3.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Packed_F64x3.Validation.Valid (Slice, Ignore_Errant),
+                   "Packed_F64x3.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + D_Bytes'Length - 1) := [others => 0];
+
+         -- LE
+         Big (Offset .. Offset + D_Bytes_Le'Length - 1) := D_Bytes_Le;
+         declare
+            Slice : Packed_F64x3.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Packed_F64x3.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Packed_F64x3.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + D_Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Simple_Array -- 17 x Short_Int (range 1..999), U16. Byte-aligned
+   -- 2-byte elements. Valid + invalid. BE + LE.
+   --------------------------------------------------------------------
+   declare
+      Valid_Bytes : constant Simple_Array.Serialization.Byte_Array :=
+         Simple_Array.Serialization.To_Byte_Array ([others => 5]);
+      Valid_Bytes_Le : constant Simple_Array.Serialization_Le.Byte_Array :=
+         Simple_Array.Serialization_Le.To_Byte_Array ([others => 5]);
+      Invalid_Bytes : Simple_Array.Serialization.Byte_Array := Valid_Bytes;
+      Invalid_Bytes_Le : Simple_Array.Serialization_Le.Byte_Array := Valid_Bytes_Le;
+   begin
+      Invalid_Bytes (4) := 16#FF#;
+      Invalid_Bytes (5) := 16#FF#;
+      Invalid_Bytes_Le (4) := 16#FF#;
+      Invalid_Bytes_Le (5) := 16#FF#;
+      for Offset in 0 .. 3 loop
+         -- BE valid
+         Big (Offset .. Offset + Valid_Bytes'Length - 1) := Valid_Bytes;
+         declare
+            Slice : Simple_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Simple_Array.Validation.Valid (Slice, Ignore_Errant),
+                   "Simple_Array.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Valid_Bytes'Length - 1) := [others => 0];
+
+         -- BE invalid
+         Big (Offset .. Offset + Invalid_Bytes'Length - 1) := Invalid_Bytes;
+         declare
+            Slice : Simple_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Errant : Unsigned_32;
+            Ok : constant Boolean := Simple_Array.Validation.Valid (Slice, Errant);
+         begin
+            Check (not Ok, "Simple_Array.Valid invalid offset" & Offset'Image);
+            Check (Errant = 3, "Simple_Array Errant=3 offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Invalid_Bytes'Length - 1) := [others => 0];
+
+         -- LE valid
+         Big (Offset .. Offset + Valid_Bytes_Le'Length - 1) := Valid_Bytes_Le;
+         declare
+            Slice : Simple_Array.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Simple_Array.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Simple_Array.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Valid_Bytes_Le'Length - 1) := [others => 0];
+
+         -- LE invalid
+         Big (Offset .. Offset + Invalid_Bytes_Le'Length - 1) := Invalid_Bytes_Le;
+         declare
+            Slice : Simple_Array.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Errant : Unsigned_32;
+            Ok : constant Boolean := Simple_Array.Validation.Valid_Le (Slice, Errant);
+         begin
+            Check (not Ok, "Simple_Array.Valid_Le invalid offset" & Offset'Image);
+            Check (Errant = 3, "Simple_Array Errant_Le=3 offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Invalid_Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Unaligned_Array -- 8 x Short_Int (range 0..999), U10. Sub-byte;
+   -- always-slow-path. BE + LE.
+   --------------------------------------------------------------------
+   declare
+      U_Valid : constant Unaligned_Array.Serialization.Byte_Array :=
+         Unaligned_Array.Serialization.To_Byte_Array ([others => 7]);
+      U_Valid_Le : constant Unaligned_Array.Serialization_Le.Byte_Array :=
+         Unaligned_Array.Serialization_Le.To_Byte_Array ([others => 7]);
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + U_Valid'Length - 1) := U_Valid;
+         declare
+            Slice : Unaligned_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Unaligned_Array.Validation.Valid (Slice, Ignore_Errant),
+                   "Unaligned_Array.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + U_Valid'Length - 1) := [others => 0];
+
+         Big (Offset .. Offset + U_Valid_Le'Length - 1) := U_Valid_Le;
+         declare
+            Slice : Unaligned_Array.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Unaligned_Array.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Unaligned_Array.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + U_Valid_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Complex_Float_Array -- record-of-floats packed element. BE only
+   -- (this type is BE).
+   --------------------------------------------------------------------
+   declare
+      CF_Bytes : constant Complex_Float_Array.Serialization.Byte_Array :=
+         Complex_Float_Array.Serialization.To_Byte_Array (
+            [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345))]);
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + CF_Bytes'Length - 1) := CF_Bytes;
+         declare
+            Slice : Complex_Float_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Complex_Float_Array.Validation.Valid (Slice, Ignore_Errant),
+                   "Complex_Float_Array.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + CF_Bytes'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Nested_Float_Array -- packed array of (packed array of
+   -- Short_Float). The outer T'Alignment must propagate from the
+   -- inner array's component alignment (4) rather than collapsing
+   -- to 1 like it would for a packed-record element. A regression in
+   -- gen/models/array.py's required_alignment computation that lumps
+   -- packed-array elements in with packed-record elements would fire
+   -- the parallel pragma Compile_Time_Error and fail the build, so
+   -- this section is mainly here to make sure the path is covered
+   -- and to exercise the runtime overlay at every byte offset 0..3
+   -- on a 4-aligned base. BE only (the element type Packed_F32x3.T
+   -- is BE so the outer array's endianness is locked to BE).
+   --------------------------------------------------------------------
+   declare
+      Nf_Bytes : constant Nested_Float_Array.Serialization.Byte_Array :=
+         Nested_Float_Array.Serialization.To_Byte_Array (
+            [others => [others => 1.5]]);
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + Nf_Bytes'Length - 1) := Nf_Bytes;
+         declare
+            Slice : Nested_Float_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Nested_Float_Array.Validation.Valid (Slice, Ignore_Errant),
+                   "Nested_Float_Array.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Nf_Bytes'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Nested_Unaligned_Array -- packed array of (packed array of
+   -- 10-bit Short_Int). Inner element byte size = 10, so the outer's
+   -- T'Alignment GNAT picks is 2 (greatest pow2 factor of 10).
+   -- Confirms the byte-aligned-element rule handles non-pow2 element
+   -- byte sizes correctly. BE only.
+   --------------------------------------------------------------------
+   declare
+      Nu_Bytes : constant Nested_Unaligned_Array.Serialization.Byte_Array :=
+         Nested_Unaligned_Array.Serialization.To_Byte_Array (
+            [others => [others => 7]]);
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + Nu_Bytes'Length - 1) := Nu_Bytes;
+         declare
+            Slice : Nested_Unaligned_Array.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Nested_Unaligned_Array.Validation.Valid (Slice, Ignore_Errant),
+                   "Nested_Unaligned_Array.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Nu_Bytes'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Complex_Array_Le -- LE record-element variant. Exercises
+   -- Valid_Le path for the packed-record-element case (LE only --
+   -- this type is LE).
+   --------------------------------------------------------------------
+   declare
+      CL_Bytes : constant Complex_Array_Le.Serialization_Le.Byte_Array :=
+         Complex_Array_Le.Serialization_Le.To_Byte_Array (
+            [others => (One => 0, Two => 19, Three => 5)]);
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + CL_Bytes'Length - 1) := CL_Bytes;
+         declare
+            Slice : Complex_Array_Le.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Complex_Array_Le.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Complex_Array_Le.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + CL_Bytes'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   -- AUnit text-reporter-style summary, picked up by the cross runner.
+   New_Line;
+   Put_Line ("Total Tests Run:   " & Total'Image);
+   Put_Line ("Successful Tests:  " & Natural'Image (Total - Failed));
+   Put_Line ("Failed Assertions: " & Failed'Image);
+   Put_Line ("Unexpected Errors:  0");
+end Test;

--- a/gen/test/records/test_misalign/env.py
+++ b/gen/test/records/test_misalign/env.py
@@ -1,0 +1,16 @@
+from environments import test, modify_build_path  # noqa: F401
+import os
+
+this_dir = os.path.dirname(os.path.realpath(__file__))
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/records/test_misalign/test.adb
+++ b/gen/test/records/test_misalign/test.adb
@@ -1,0 +1,255 @@
+--------------------------------------------------------------------------------
+-- Misalignment-resilience test for the packed-record Validation autocode,
+-- structured specifically to be runnable on cross-compiled bareboard
+-- targets, which is the real point of this file. Alignment-related bugs
+-- in the autocode behave very differently per host:
+--
+--   * x86_64 Linux silently handles misaligned typed loads, so the same
+--     bug that traps on bareboard reads "correctly" on the host. Linux
+--     tests will pass even when the autocode is alignment-fragile -- so
+--     a host-only regression test cannot catch this class of bug.
+--
+--   * Cross embedded targets can trap or return
+--     garbage bits on misaligned typed loads, either of which makes
+--     this test fail loudly.
+--
+-- Why this lives in its own directory rather than as a section of the
+-- companion gen/test/records/test/test.adb (and follows a different
+-- pattern than the rest of gen/test):
+--
+--   1. The companion test pulls in heavy string-formatting plumbing
+--      that overflows the embedded runtime's secondary stack on
+--      bareboard. This file is sized to fit.
+--
+--   2. The pattern is intentionally different: no `pragma Assert`
+--      (suppressible by `pragma Suppress (Assertion_Check)` and
+--      ignored under `Assertion_Policy => Ignore` profiles) -- instead
+--      a `Check` helper procedure that always runs and increments a
+--      counter. The summary at the end is AUnit-text-reporter-format
+--      ("Total Tests Run: N / Failed Assertions: 0 / Unexpected
+--      Errors: 0") so the cross-test renode runner can scrape pass/
+--      fail without parsing Put_Line transcripts.
+--
+-- The record-template-specific thing this exercises: the record
+-- validation template's "no copy needed" decision rests on
+-- bit-packed-record codegen producing byte-extract reads at any byte
+-- address (T'Alignment = 1, asserted at build time via the template's
+-- pragma Compile_Time_Error). The Compile_Time_Error catches a future
+-- change that loosens that invariant; this test catches a runtime
+-- regression in the bit-extract codegen at every byte offset 0..3.
+--
+-- Per RM 13.3(13/3):
+--   "If an Address is specified, it is the programmer's responsibility
+--   to ensure that the address is valid and appropriate for the entity
+--   and its use; otherwise, program execution is erroneous."
+--   (http://www.ada-auth.org/standards/22rm/html/RM-13-3.html)
+
+with Ada.Text_IO; use Ada.Text_IO;
+with Always_Valid_Simple;
+with Always_Valid_Simple.Validation;
+with Aa;
+with Aa.Validation;
+with Ff;
+with Ff.Validation;
+with Basic_Types;
+with Interfaces; use Interfaces;
+
+procedure Test is
+   --  Big buffer, explicitly 4-aligned.
+   Big : aliased Basic_Types.Byte_Array (0 .. 255) := [others => 0];
+   for Big'Alignment use 4;
+
+   Total : Natural := 0;
+   Failed : Natural := 0;
+
+   procedure Check (Cond : Boolean; Message : String) is
+   begin
+      Total := Total + 1;
+      if not Cond then
+         Failed := Failed + 1;
+         Put_Line ("  FAIL: " & Message);
+      end if;
+   end Check;
+begin
+   Put_Line ("Validation misalignment tests (records):");
+
+   --------------------------------------------------------------------
+   -- Always_Valid_Simple -- U8 + U16 + U32, no range checks. BE + LE.
+   --------------------------------------------------------------------
+   declare
+      Bytes : constant Always_Valid_Simple.Serialization.Byte_Array :=
+         Always_Valid_Simple.Serialization.To_Byte_Array (
+            (A => 16#A5#, B => 16#1234#, C => 16#DEADBEEF#));
+      Bytes_Le : constant Always_Valid_Simple.Serialization_Le.Byte_Array :=
+         Always_Valid_Simple.Serialization_Le.To_Byte_Array (
+            (A => 16#A5#, B => 16#1234#, C => 16#DEADBEEF#));
+   begin
+      for Offset in 0 .. 3 loop
+         Big (Offset .. Offset + Bytes'Length - 1) := Bytes;
+         declare
+            Slice : Always_Valid_Simple.Serialization.Byte_Array
+               with Import, Convention => Ada,
+                    Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Always_Valid_Simple.Validation.Valid (Slice, Ignore_Errant),
+                   "Always_Valid_Simple.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Bytes'Length - 1) := [others => 0];
+
+         Big (Offset .. Offset + Bytes_Le'Length - 1) := Bytes_Le;
+         declare
+            Slice : Always_Valid_Simple.Serialization_Le.Byte_Array
+               with Import, Convention => Ada,
+                    Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Always_Valid_Simple.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Always_Valid_Simple.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Aa -- range-constrained U8 + U8 + U16. Valid + invalid path.
+   -- BE + LE.
+   --------------------------------------------------------------------
+   declare
+      Valid_Bytes : constant Aa.Serialization.Byte_Array :=
+         Aa.Serialization.To_Byte_Array ((One => 4, Two => 20, Three => 101));
+      Valid_Bytes_Le : constant Aa.Serialization_Le.Byte_Array :=
+         Aa.Serialization_Le.To_Byte_Array ((One => 4, Two => 20, Three => 101));
+      Invalid_Bytes : Aa.Serialization.Byte_Array := Valid_Bytes;
+      Invalid_Bytes_Le : Aa.Serialization_Le.Byte_Array := Valid_Bytes_Le;
+   begin
+      Invalid_Bytes (Invalid_Bytes'First) := 16#FF#;  -- One out of range
+      Invalid_Bytes_Le (Invalid_Bytes_Le'First) := 16#FF#;
+      for Offset in 0 .. 3 loop
+         -- BE valid
+         Big (Offset .. Offset + Valid_Bytes'Length - 1) := Valid_Bytes;
+         declare
+            Slice : Aa.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Aa.Validation.Valid (Slice, Ignore_Errant),
+                   "Aa.Valid offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Valid_Bytes'Length - 1) := [others => 0];
+
+         -- BE invalid
+         Big (Offset .. Offset + Invalid_Bytes'Length - 1) := Invalid_Bytes;
+         declare
+            Slice : Aa.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Errant : Unsigned_32;
+            Ok : constant Boolean := Aa.Validation.Valid (Slice, Errant);
+         begin
+            Check (not Ok, "Aa.Valid invalid offset" & Offset'Image);
+            Check (Errant = 1, "Aa Errant=1 offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Invalid_Bytes'Length - 1) := [others => 0];
+
+         -- LE valid
+         Big (Offset .. Offset + Valid_Bytes_Le'Length - 1) := Valid_Bytes_Le;
+         declare
+            Slice : Aa.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Aa.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Aa.Valid_Le offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Valid_Bytes_Le'Length - 1) := [others => 0];
+
+         -- LE invalid
+         Big (Offset .. Offset + Invalid_Bytes_Le'Length - 1) := Invalid_Bytes_Le;
+         declare
+            Slice : Aa.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Errant : Unsigned_32;
+            Ok : constant Boolean := Aa.Validation.Valid_Le (Slice, Errant);
+         begin
+            Check (not Ok, "Aa.Valid_Le invalid offset" & Offset'Image);
+            Check (Errant = 1, "Aa Errant_Le=1 offset" & Offset'Image);
+         end;
+         Big (Offset .. Offset + Invalid_Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   --------------------------------------------------------------------
+   -- Ff -- U8 + Short_Float (F32) + Long_Float (F64). The FP loads
+   -- are the alignment-sensitive case. F32 is at within-record
+   -- byte 1 and F64 at byte 5, so even at outer offset 0 the inner
+   -- FP fields are at within-record misalignments. BE + LE.
+   --------------------------------------------------------------------
+   declare
+      Bytes : constant Ff.Serialization.Byte_Array :=
+         Ff.Serialization.To_Byte_Array (
+            (One => 7, Two => 1.5, Three => 2.71828182845904523));
+      Bytes_Le : constant Ff.Serialization_Le.Byte_Array :=
+         Ff.Serialization_Le.To_Byte_Array (
+            (One => 7, Two => 1.5, Three => 2.71828182845904523));
+   begin
+      for Offset in 0 .. 3 loop
+         -- BE
+         Big (Offset .. Offset + Bytes'Length - 1) := Bytes;
+         declare
+            Slice : Ff.Serialization.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Ff.Validation.Valid (Slice, Ignore_Errant),
+                   "Ff.Valid offset" & Offset'Image);
+            -- Force every Get_Field path to fire its byte-extract loads.
+            declare
+               One : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field (Slice, 1);
+               Two : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field (Slice, 2);
+               Three : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field (Slice, 3);
+            begin
+               Check (One (One'Last) = 7,
+                      "Ff Get_Field One offset" & Offset'Image);
+               Check (Two'Length > 0 and then Three'Length > 0,
+                      "Ff Get_Field FP-readback offset" & Offset'Image);
+            end;
+         end;
+         Big (Offset .. Offset + Bytes'Length - 1) := [others => 0];
+
+         -- LE
+         Big (Offset .. Offset + Bytes_Le'Length - 1) := Bytes_Le;
+         declare
+            Slice : Ff.Serialization_Le.Byte_Array
+               with Import, Convention => Ada, Address => Big (Offset)'Address;
+            Ignore_Errant : Unsigned_32;
+         begin
+            Check (Ff.Validation.Valid_Le (Slice, Ignore_Errant),
+                   "Ff.Valid_Le offset" & Offset'Image);
+            declare
+               One : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field_Le (Slice, 1);
+               Two : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field_Le (Slice, 2);
+               Three : constant Basic_Types.Poly_Type :=
+                  Ff.Validation.Get_Field_Le (Slice, 3);
+            begin
+               Check (One (One'Last) = 7,
+                      "Ff Get_Field_Le One offset" & Offset'Image);
+               Check (Two'Length > 0 and then Three'Length > 0,
+                      "Ff Get_Field_Le FP-readback offset" & Offset'Image);
+            end;
+         end;
+         Big (Offset .. Offset + Bytes_Le'Length - 1) := [others => 0];
+      end loop;
+   end;
+
+   -- AUnit text-reporter-style summary, picked up by the cross runner.
+   New_Line;
+   Put_Line ("Total Tests Run:   " & Total'Image);
+   Put_Line ("Successful Tests:  " & Natural'Image (Total - Failed));
+   Put_Line ("Failed Assertions: " & Failed'Image);
+   Put_Line ("Unexpected Errors:  0");
+end Test;


### PR DESCRIPTION
## Summary

The packed array Validation autocode (`Valid` / `Valid_Le` / `Get_Field` / `Get_Field_Le`, generated from `gen/templates/array/name-validation.adb`) overlaid the typed view directly on the input `Bytes`:

```ada
R : T with Import, Convention => Ada, Address => Bytes'Address;
```

If `Bytes`' runtime address didn't satisfy `T'Alignment`, this is **erroneous** per Ada 2022 RM 13.3(13/3). In practice that means silent garbage / right-answer-by-luck on x86_64 Linux, and traps / garbage-bit reads on alignment-strict bareboard targets like RV32IMAF.

Note that this issue does not affect packed records, since packed records all have Alignment of 1. GNAT does not allow compilation of packed arrays with an Alignment set to 1, which is the important difference.

## What changed

`Valid` / `Get_Field` now picks one of three runtime patterns based on the element shape (computed in `gen/models/array.py` as `required_alignment`):

- **Packed-record element** (`T'Alignment = 1`) — direct overlay, no copy needed.
- **Byte-aligned primitive** (`Short_Float`, `Unsigned_32`, `Long_Float`, …) — fast path overlays directly when `Bytes`' runtime address already satisfies `T'Alignment`; slow path copies into an aligned local `Byte_Array` and overlays on the copy.
- **Sub-byte primitive** (e.g. `T'Component_Size = 10`) — always copy into the aligned local. GNAT's bit-extract codegen still issues word loads under the hood, so a misaligned direct overlay reads garbage on bareboard.

`required_alignment` is computed in the array model and asserted to be a power of 2 at codegen time. Combined with the GNAT-RM 10.1 guarantee that "all default alignments are always a power of 2," a single `pragma Compile_Time_Error (T'Alignment > required_alignment, …)` at every overlay site is sufficient as a safety check (pow2-and-pow2-and-greater-or-equal implies "our literal is a multiple of `T'Alignment`," the second half of the RM 13.3(13/3) safety condition).

The record validation template gets a parallel `pragma Compile_Time_Error (T'Alignment /= 1, …)` at every overlay site to lock in the bit-packed-record codegen invariant.

## New tests

- `gen/test/arrays/test/test.adb` — added a "Validation misalignment tests" section that overlays each test array (Float_Array, Simple_Array, Unaligned_Array, Complex_Float_Array, Complex_Array_Le) at byte offsets 0..3 and exercises `Valid` / `Valid_Le` and `Get_Field` / `Get_Field_Le`.
- `gen/test/arrays/test_misalign/` — standalone bareboard variant of the same coverage, sized to fit the embedded runtime's secondary stack. Reports in AUnit text-reporter format so cross-test runners can scrape pass/fail.
- `gen/test/records/test_misalign/` — companion that exercises the record template's direct overlay (Always_Valid_Simple, Aa, Ff with Short_Float + Long_Float fields) at byte offsets 0..3, BE + LE.