### PR TITLE
Add dropped message count data product to connector_queuer

### DIFF
--- a/src/components/connector_queuer/component-connector_queuer-implementation.adb
+++ b/src/components/connector_queuer/component-connector_queuer-implementation.adb
@@ -4,6 +4,13 @@
 
 package body Component.Connector_Queuer.Implementation is
 
+   -- Initialize the dropped message count and send its initial value:
+   overriding procedure Set_Up (Self : in out Instance) is
+   begin
+      Self.Dropped_Message_Count.Set_Count (0);
+      Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Dropped_Message_Count (Self.Sys_Time_T_Get, (Value => Self.Dropped_Message_Count.Get_Count)));
+   end Set_Up;
+
    ---------------------------------------
    -- Invokee connector primitives:
    ---------------------------------------
@@ -17,9 +24,14 @@ package body Component.Connector_Queuer.Implementation is
    -- This procedure is called when a T_Recv_Async message is dropped due to a full queue.
    overriding procedure T_Recv_Async_Dropped (Self : in out Instance; Arg : in T) is
       Ignore : T renames Arg;
+      The_Time : constant Sys_Time.T := Self.Sys_Time_T_Get;
    begin
+      -- Increment the dropped message count and report it as a data product:
+      Self.Dropped_Message_Count.Increment_Count;
+      Self.Data_Product_T_Send_If_Connected (Self.Data_Products.Dropped_Message_Count (The_Time, (Value => Self.Dropped_Message_Count.Get_Count)));
+
       -- Throw event:
-      Self.Event_T_Send_If_Connected (Self.Events.Dropped_Message (Self.Sys_Time_T_Get));
+      Self.Event_T_Send_If_Connected (Self.Events.Dropped_Message (The_Time));
    end T_Recv_Async_Dropped;
 
 end Component.Connector_Queuer.Implementation;

--- a/src/components/connector_queuer/component-connector_queuer-implementation.ads
+++ b/src/components/connector_queuer/component-connector_queuer-implementation.ads
@@ -2,6 +2,10 @@
 -- Connector_Queuer Component Implementation Spec
 --------------------------------------------------------------------------------
 
+-- Includes:
+with Interfaces;
+with Protected_Variables;
+
 -- This is a generic component that can be used to queue (as in recv_async) the call to an input connector. The component allows a queue to be added in front of the a synchronous connector in any component. Adding a queue to a component not designed with thread-safety in mind can serve as a multi-tasking safe synchronization point for multiple callers. When the T_Recv_Async connector is called, the data is queued. Based on the priority of this component, the data will be safely dequeued in the future and the T_Send connector will be called. The queue is implemented using the standard Adamant queue, and thus calls are serviced in FIFO order. The queue protection mechanism effectively makes all downstream connector calls of this component thread-safe. The advantage of this component is that deploying it appropriately in an assembly can provide thread-safety and priority-tuned FIFO execution to components which are not designed to be thread-safe in and of themselves.
 generic
 package Component.Connector_Queuer.Implementation is
@@ -11,9 +15,14 @@ package Component.Connector_Queuer.Implementation is
 
 private
 
+   -- Instantiate protected 16 bit counter. The dropped message count is updated
+   -- from the calling task's context when the queue is full, so a protected
+   -- counter is used to remain safe across concurrent callers.
+   package Sixteen_Counter is new Protected_Variables.Generic_Protected_Counter (Interfaces.Unsigned_16);
+
    -- The component class instance record:
    type Instance is new Connector_Queuer.Base_Instance with record
-      null; -- No internal state
+      Dropped_Message_Count : Sixteen_Counter.Counter;
    end record;
 
    ---------------------------------------
@@ -26,7 +35,7 @@ private
    -- safely until everything is up and running, i.e. command registration, initial
    -- data product updates. This procedure should be implemented to do these things
    -- if necessary.
-   overriding procedure Set_Up (Self : in out Instance) is null;
+   overriding procedure Set_Up (Self : in out Instance);
 
    ---------------------------------------
    -- Invokee connector primitives:
@@ -41,6 +50,8 @@ private
    ---------------------------------------
    -- This procedure is called when a T_Send message is dropped due to a full queue.
    overriding procedure T_Send_Dropped (Self : in out Instance; Arg : in T) is null;
+   -- This procedure is called when a Data_Product_T_Send message is dropped due to a full queue.
+   overriding procedure Data_Product_T_Send_Dropped (Self : in out Instance; Arg : in Data_Product.T) is null;
    -- This procedure is called when a Event_T_Send message is dropped due to a full queue.
    overriding procedure Event_T_Send_Dropped (Self : in out Instance; Arg : in Event.T) is null;
 

--- a/src/components/connector_queuer/connector_queuer.component.yaml
+++ b/src/components/connector_queuer/connector_queuer.component.yaml
@@ -21,6 +21,9 @@ connectors:
   - description: The system time is retrieved via this connector.
     return_type: Sys_Time.T
     kind: get
+  - description: The dropped message count is sent out of this connector.
+    type: Data_Product.T
+    kind: send
   - description: Events are sent out of this connector.
     type: Event.T
     kind: send

--- a/src/components/connector_queuer/connector_queuer.data_products.yaml
+++ b/src/components/connector_queuer/connector_queuer.data_products.yaml
@@ -1,0 +1,6 @@
+---
+description: Data products for the connector queuer component.
+data_products:
+  - name: Dropped_Message_Count
+    description: The number of messages dropped due to queue overflow. The count rolls over at 65535 and is 2 bytes wide.
+    type: Packed_U16.T

--- a/src/components/connector_queuer/test/component-connector_queuer-implementation-tester.adb
+++ b/src/components/connector_queuer/test/component-connector_queuer-implementation-tester.adb
@@ -2,6 +2,7 @@
 -- Connector_Queuer Component Tester Body
 --------------------------------------------------------------------------------
 
+-- Includes:
 with String_Util;
 
 package body Component.Connector_Queuer.Implementation.Tester is
@@ -18,9 +19,12 @@ package body Component.Connector_Queuer.Implementation.Tester is
       -- Connector histories:
       Self.T_Recv_Sync_History.Init (Depth => 100);
       Self.Sys_Time_T_Return_History.Init (Depth => 100);
+      Self.Data_Product_T_Recv_Sync_History.Init (Depth => 100);
       Self.Event_T_Recv_Sync_History.Init (Depth => 100);
       -- Event histories:
       Self.Dropped_Message_History.Init (Depth => 100);
+      -- Data product histories:
+      Self.Dropped_Message_Count_History.Init (Depth => 100);
    end Init_Base;
 
    procedure Final_Base (Self : in out Instance) is
@@ -29,9 +33,12 @@ package body Component.Connector_Queuer.Implementation.Tester is
       -- Connector histories:
       Self.T_Recv_Sync_History.Destroy;
       Self.Sys_Time_T_Return_History.Destroy;
+      Self.Data_Product_T_Recv_Sync_History.Destroy;
       Self.Event_T_Recv_Sync_History.Destroy;
       -- Event histories:
       Self.Dropped_Message_History.Destroy;
+      -- Data product histories:
+      Self.Dropped_Message_Count_History.Destroy;
 
       -- Destroy component heap:
       Self.Component_Instance.Final_Base;
@@ -44,6 +51,7 @@ package body Component.Connector_Queuer.Implementation.Tester is
    begin
       Self.Component_Instance.Attach_T_Send (To_Component => Self'Unchecked_Access, Hook => Self.T_Recv_Sync_Access);
       Self.Component_Instance.Attach_Sys_Time_T_Get (To_Component => Self'Unchecked_Access, Hook => Self.Sys_Time_T_Return_Access);
+      Self.Component_Instance.Attach_Data_Product_T_Send (To_Component => Self'Unchecked_Access, Hook => Self.Data_Product_T_Recv_Sync_Access);
       Self.Component_Instance.Attach_Event_T_Send (To_Component => Self'Unchecked_Access, Hook => Self.Event_T_Recv_Sync_Access);
       Self.Attach_T_Send (To_Component => Self.Component_Instance'Unchecked_Access, Hook => Self.Component_Instance.T_Recv_Async_Access);
    end Connect;
@@ -51,7 +59,9 @@ package body Component.Connector_Queuer.Implementation.Tester is
    ---------------------------------------
    -- Invokee connector primitives:
    ---------------------------------------
-   -- The generic invoker connector. Calls originating from this connector are serviced from the component's queue and thus will be executed in FIFO order in a thread-safe, atomic manner.
+   -- The generic invoker connector. Calls originating from this connector are
+   -- serviced from the component's queue and thus will be executed in FIFO order in
+   -- a thread-safe, atomic manner.
    overriding procedure T_Recv_Sync (Self : in out Instance; Arg : in T) is
    begin
       -- Push the argument onto the test history for looking at later:
@@ -60,14 +70,22 @@ package body Component.Connector_Queuer.Implementation.Tester is
 
    -- The system time is retrieved via this connector.
    overriding function Sys_Time_T_Return (Self : in out Instance) return Sys_Time.T is
-      To_Return : Sys_Time.T;
-   begin
       -- Return the system time:
-      To_Return := Self.System_Time;
+      To_Return : constant Sys_Time.T := Self.System_Time;
+   begin
       -- Push the argument onto the test history for looking at later:
       Self.Sys_Time_T_Return_History.Push (To_Return);
       return To_Return;
    end Sys_Time_T_Return;
+
+   -- The dropped message count is sent out of this connector.
+   overriding procedure Data_Product_T_Recv_Sync (Self : in out Instance; Arg : in Data_Product.T) is
+   begin
+      -- Push the argument onto the test history for looking at later:
+      Self.Data_Product_T_Recv_Sync_History.Push (Arg);
+      -- Dispatch the data product to the correct handler:
+      Self.Dispatch_Data_Product (Arg);
+   end Data_Product_T_Recv_Sync;
 
    -- Events are sent out of this connector.
    overriding procedure Event_T_Recv_Sync (Self : in out Instance; Arg : in Event.T) is
@@ -103,6 +121,19 @@ package body Component.Connector_Queuer.Implementation.Tester is
       -- Push the argument onto the test history for looking at later:
       Self.Dropped_Message_History.Push (Arg);
    end Dropped_Message;
+
+   -----------------------------------------------
+   -- Data product handler primitive:
+   -----------------------------------------------
+   -- Description:
+   --    Data products for the connector queuer component.
+   -- The number of messages dropped due to queue overflow. The count rolls over at
+   -- 65535 and is 2 bytes wide.
+   overriding procedure Dropped_Message_Count (Self : in out Instance; Arg : in Packed_U16.T) is
+   begin
+      -- Push the argument onto the test history for looking at later:
+      Self.Dropped_Message_Count_History.Push (Arg);
+   end Dropped_Message_Count;
 
    -----------------------------------------------
    -- Special primitives for activating component

--- a/src/components/connector_queuer/test/component-connector_queuer-implementation-tester.ads
+++ b/src/components/connector_queuer/test/component-connector_queuer-implementation-tester.ads
@@ -4,14 +4,28 @@
 
 -- Includes:
 with Component.Connector_Queuer_Reciprocal;
-with Sys_Time;
 with Printable_History;
 with History;
 with Sys_Time.Representation;
+with Data_Product.Representation;
 with Event.Representation;
+with Data_Product;
+with Packed_U16.Representation;
 with Event;
 
--- This is a generic component that can be used to queue (as in recv_async) the call to an input connector. The component allows a queue to be added in front of the a synchronous connector in any component. Adding a queue to a component not designed with thread-safety in mind can serve as a multi-tasking safe synchronization point for multiple callers. When the T_Recv_Async connector is called, the data is queued. Based on the priority of this component, the data will be safely dequeued in the future and the T_Send connector will be called. The queue is implemented using the standard Adamant queue, and thus calls are serviced in FIFO order. The queue protection mechanism effectively makes all downstream connector calls of this component thread-safe. The advantage of this component is that deploying it appropriately in an assembly can provide thread-safety and priority-tuned FIFO execution to components which are not designed to be thread-safe in and of themselves.
+-- This is a generic component that can be used to queue (as in recv_async) the
+-- call to an input connector. The component allows a queue to be added in front
+-- of a synchronous connector in any component. Adding a queue to a component not
+-- designed with thread-safety in mind can serve as a multi-tasking safe
+-- synchronization point for multiple callers. When the T_Recv_Async connector is
+-- called, the data is queued. Based on the priority of this component, the data
+-- will be safely dequeued in the future and the T_Send connector will be called.
+-- The queue is implemented using the standard Adamant queue, and thus calls are
+-- serviced in FIFO order. The queue protection mechanism effectively makes all
+-- downstream connector calls of this component thread-safe. The advantage of this
+-- component is that deploying it appropriately in an assembly can provide thread-
+-- safety and priority-tuned FIFO execution to components which are not designed
+-- to be thread-safe in and of themselves.
 generic
 package Component.Connector_Queuer.Implementation.Tester is
 
@@ -19,10 +33,14 @@ package Component.Connector_Queuer.Implementation.Tester is
    -- Invoker connector history packages:
    package T_Recv_Sync_History_Package is new History (T);
    package Sys_Time_T_Return_History_Package is new Printable_History (Sys_Time.T, Sys_Time.Representation.Image);
+   package Data_Product_T_Recv_Sync_History_Package is new Printable_History (Data_Product.T, Data_Product.Representation.Image);
    package Event_T_Recv_Sync_History_Package is new Printable_History (Event.T, Event.Representation.Image);
 
    -- Event history packages:
    package Dropped_Message_History_Package is new Printable_History (Natural, Natural'Image);
+
+   -- Data product history packages:
+   package Dropped_Message_Count_History_Package is new Printable_History (Packed_U16.T, Packed_U16.Representation.Image);
 
    -- Component class instance:
    type Instance is new Connector_Queuer_Package.Base_Instance with record
@@ -31,9 +49,12 @@ package Component.Connector_Queuer.Implementation.Tester is
       -- Connector histories:
       T_Recv_Sync_History : T_Recv_Sync_History_Package.Instance;
       Sys_Time_T_Return_History : Sys_Time_T_Return_History_Package.Instance;
+      Data_Product_T_Recv_Sync_History : Data_Product_T_Recv_Sync_History_Package.Instance;
       Event_T_Recv_Sync_History : Event_T_Recv_Sync_History_Package.Instance;
       -- Event histories:
       Dropped_Message_History : Dropped_Message_History_Package.Instance;
+      -- Data product histories:
+      Dropped_Message_Count_History : Dropped_Message_Count_History_Package.Instance;
       -- Booleans to control assertion if message is dropped on async queue:
       Expect_T_Send_Dropped : Boolean := False;
       T_Send_Dropped_Count : Natural := 0;
@@ -54,10 +75,14 @@ package Component.Connector_Queuer.Implementation.Tester is
    ---------------------------------------
    -- Invokee connector primitives:
    ---------------------------------------
-   -- The generic invoker connector. Calls originating from this connector are serviced from the component's queue and thus will be executed in FIFO order in a thread-safe, atomic manner.
+   -- The generic invoker connector. Calls originating from this connector are
+   -- serviced from the component's queue and thus will be executed in FIFO order in
+   -- a thread-safe, atomic manner.
    overriding procedure T_Recv_Sync (Self : in out Instance; Arg : in T);
    -- The system time is retrieved via this connector.
    overriding function Sys_Time_T_Return (Self : in out Instance) return Sys_Time.T;
+   -- The dropped message count is sent out of this connector.
+   overriding procedure Data_Product_T_Recv_Sync (Self : in out Instance; Arg : in Data_Product.T);
    -- Events are sent out of this connector.
    overriding procedure Event_T_Recv_Sync (Self : in out Instance; Arg : in Event.T);
 
@@ -72,6 +97,15 @@ package Component.Connector_Queuer.Implementation.Tester is
    -----------------------------------------------
    -- The queue overflowed and the incoming data was dropped.
    overriding procedure Dropped_Message (Self : in out Instance);
+
+   -----------------------------------------------
+   -- Data product handler primitives:
+   -----------------------------------------------
+   -- Description:
+   --    Data products for the connector queuer component.
+   -- The number of messages dropped due to queue overflow. The count rolls over at
+   -- 65535 and is 2 bytes wide.
+   overriding procedure Dropped_Message_Count (Self : in out Instance; Arg : in Packed_U16.T);
 
    -----------------------------------------------
    -- Special primitives for activating component

--- a/src/components/connector_queuer/test/connector_queuer.tests.yaml
+++ b/src/components/connector_queuer/test/connector_queuer.tests.yaml
@@ -5,3 +5,5 @@ tests:
     description: This unit test invokes the async connector and makes sure the arguments are passed through asynchronously, as expected.
   - name: Test_Full_Queue
     description: This unit test fills the queue and makes sure that dropped messages are reported.
+  - name: Test_Dropped_Message_Count
+    description: This unit test overflows the queue multiple times and makes sure that the dropped message count data product accumulates and is reported on each drop.

--- a/src/components/connector_queuer/test/connector_queuer_tests-implementation.adb
+++ b/src/components/connector_queuer/test/connector_queuer_tests-implementation.adb
@@ -5,6 +5,7 @@
 with Safe_Deallocator;
 with Basic_Assertions; use Basic_Assertions;
 with Tick.Assertion; use Tick.Assertion;
+with Packed_U16.Assertion; use Packed_U16.Assertion;
 
 package body Connector_Queuer_Tests.Implementation is
 
@@ -48,6 +49,11 @@ package body Connector_Queuer_Tests.Implementation is
    overriding procedure Test_Queued_Call (Self : in out Instance) is
       T : Component_Tester_Package.Instance_Access renames Self.Tester;
    begin
+      -- Set_Up sends the initial dropped message count data product (zero):
+      Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 1);
+      Natural_Assert.Eq (T.Dropped_Message_Count_History.Get_Count, 1);
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (1), (Value => 0));
+
       -- Call the connector:
       T.T_Send (((1, 2), 3));
       Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 0);
@@ -80,6 +86,13 @@ package body Connector_Queuer_Tests.Implementation is
       Tick_Assert.Eq (T.T_Recv_Sync_History.Get (4), ((8, 10), 12));
       Tick_Assert.Eq (T.T_Recv_Sync_History.Get (5), ((9, 11), 13));
       Tick_Assert.Eq (T.T_Recv_Sync_History.Get (6), ((15, 15), 15));
+
+      -- No messages were dropped, so no events were sent and the dropped message
+      -- count data product was not sent beyond the initial value from Set_Up:
+      Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 0);
+      Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 1);
+      Natural_Assert.Eq (T.Dropped_Message_Count_History.Get_Count, 1);
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (1), (Value => 0));
    end Test_Queued_Call;
 
    overriding procedure Test_Full_Queue (Self : in out Instance) is
@@ -99,6 +112,13 @@ package body Connector_Queuer_Tests.Implementation is
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 1);
       Natural_Assert.Eq (T.Dropped_Message_History.Get_Count, 1);
 
+      -- The drop incremented the dropped message count and reported it as a data
+      -- product. The Set_Up data product (zero) plus this one make two:
+      Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 2);
+      Natural_Assert.Eq (T.Dropped_Message_Count_History.Get_Count, 2);
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (1), (Value => 0));
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (2), (Value => 1));
+
       -- Expect tick to be passed through now.
       Natural_Assert.Eq (T.Dispatch_All, 3);
       Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 3);
@@ -106,5 +126,37 @@ package body Connector_Queuer_Tests.Implementation is
       Tick_Assert.Eq (T.T_Recv_Sync_History.Get (2), ((9, 11), 13));
       Tick_Assert.Eq (T.T_Recv_Sync_History.Get (3), ((15, 15), 15));
    end Test_Full_Queue;
+
+   overriding procedure Test_Dropped_Message_Count (Self : in out Instance) is
+      T : Component_Tester_Package.Instance_Access renames Self.Tester;
+   begin
+      -- Set_Up sends the initial dropped message count data product (zero):
+      Natural_Assert.Eq (T.Dropped_Message_Count_History.Get_Count, 1);
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (1), (Value => 0));
+
+      -- Fill the queue so that subsequent sends overflow it:
+      T.T_Send (((8, 10), 12));
+      T.T_Send (((9, 11), 13));
+      T.T_Send (((15, 15), 15));
+      Natural_Assert.Eq (T.T_Recv_Sync_History.Get_Count, 0);
+
+      -- Overflow the queue several times. Each drop must be expected explicitly
+      -- because Expect_T_Send_Dropped auto-resets to False after every drop:
+      for I in 1 .. 3 loop
+         T.Expect_T_Send_Dropped := True;
+         T.T_Send (((13, 13), 13));
+      end loop;
+
+      -- Each of the three drops fired an event and reported an incrementing count.
+      -- Combined with the initial Set_Up data product there are four in total:
+      Natural_Assert.Eq (T.T_Send_Dropped_Count, 3);
+      Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 3);
+      Natural_Assert.Eq (T.Dropped_Message_History.Get_Count, 3);
+      Natural_Assert.Eq (T.Data_Product_T_Recv_Sync_History.Get_Count, 4);
+      Natural_Assert.Eq (T.Dropped_Message_Count_History.Get_Count, 4);
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (2), (Value => 1));
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (3), (Value => 2));
+      Packed_U16_Assert.Eq (T.Dropped_Message_Count_History.Get (4), (Value => 3));
+   end Test_Dropped_Message_Count;
 
 end Connector_Queuer_Tests.Implementation;

--- a/src/components/connector_queuer/test/connector_queuer_tests-implementation.ads
+++ b/src/components/connector_queuer/test/connector_queuer_tests-implementation.ads
@@ -8,18 +8,25 @@ with Tick;
 
 -- This is a unit test suite for the Connector Queuer.
 package Connector_Queuer_Tests.Implementation is
+
    -- Test data and state:
    type Instance is new Connector_Queuer_Tests.Base_Instance with private;
    type Class_Access is access all Instance'Class;
+
 private
    -- Fixture procedures:
    overriding procedure Set_Up_Test (Self : in out Instance);
    overriding procedure Tear_Down_Test (Self : in out Instance);
 
-   -- This unit test invokes the async connector and makes sure the arguments are passed through asynchronously, as expected.
+   -- This unit test invokes the async connector and makes sure the arguments are
+   -- passed through asynchronously, as expected.
    overriding procedure Test_Queued_Call (Self : in out Instance);
-   -- This unit test fills the queue and makes sure that dropped messages are reported.
+   -- This unit test fills the queue and makes sure that dropped messages are
+   -- reported.
    overriding procedure Test_Full_Queue (Self : in out Instance);
+   -- This unit test overflows the queue multiple times and makes sure that the
+   -- dropped message count data product accumulates and is reported on each drop.
+   overriding procedure Test_Dropped_Message_Count (Self : in out Instance);
 
    -- Instantiate generic component package:
    package Component_Package is new Component.Connector_Queuer (T => Tick.T, Serialized_Length => Tick.Serialized_Length);


### PR DESCRIPTION
## Summary

The `connector_queuer` previously only emitted a `Dropped_Message` event when its queue overflowed, with no cumulative telemetry. This adds a `Dropped_Message_Count` data product (`Packed_U16.T`) reporting the running total of messages dropped due to queue overflow.

## Changes

- Add a `Data_Product.T` send connector to the component model and a `connector_queuer.data_products.yaml` declaring `Dropped_Message_Count`.
- Track the count with a protected 16-bit counter — the drop handler (`T_Recv_Async_Dropped`) runs on the *caller's* task, so concurrent callers are possible.
- Initialize and emit the count at `Set_Up`, and increment + report it on every drop alongside the existing event.
- Add a `Test_Dropped_Message_Count` case (overflows the queue 3× and verifies the count accumulates) and extend the existing tests to cover the new data product and the initial `Set_Up` emission.

## Verification

All run in the Docker environment:
- `redo all` — builds clean
- `redo style` — zero warnings (component + test)
- `redo test` — 3/3 pass
- `redo coverage` — 100% (14/14) on the implementation body

## Note

This adds a new connector to a generic framework component. The connector uses `Send_If_Connected`, so existing assemblies that don't wire it continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)