### PR TITLE
Make redo clean instant: rename build dirs, reclaim in background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+.build_trash/
 .vagrant
 .Trash*
 .pyenv/

--- a/redo/database/_setup.py
+++ b/redo/database/_setup.py
@@ -1,5 +1,4 @@
 import os.path
-import git
 import random
 from util import error
 from util import redo_arg
@@ -111,10 +110,8 @@ class _build_path(OrderedDict):
 
 def _get_git_root(path):
     """Get the root directory of the adamant repository."""
-    try:
-        git_repo = git.Repo(path, search_parent_directories=True)
-        git_root = git_repo.git.rev_parse("--show-toplevel")
-    except BaseException:
+    git_root = filesystem.get_git_root(path)
+    if git_root is None:
         error.error_abort(
             "No valid git repository was found containing the directory: " + str(path)
         )

--- a/redo/rules/build_clean.py
+++ b/redo/rules/build_clean.py
@@ -1,9 +1,31 @@
+import os
 import os.path
-from util import redo
-from util import debug
-from base_classes.build_rule_base import build_rule_base
+import secrets
 import subprocess
 import concurrent.futures
+from util import redo
+from util import debug
+from util import filesystem
+from base_classes.build_rule_base import build_rule_base
+
+# Name of the top-level trash directory used by the fast clean. Build
+# directories are renamed into here and reclaimed by a detached background
+# process. The leading "." ensures the build system's directory walks
+# (see util/filesystem.py) never descend into it. The entire directory is
+# garbage and is always safe to delete manually.
+TRASH_DIR_NAME = ".build_trash"
+
+
+def _fast_clean_disabled():
+    """
+    Return True if the user has disabled the fast (asynchronous) clean via
+    the DISABLE_FAST_CLEAN environment variable. Unset or "0" means fast
+    clean is enabled; any other value disables it, forcing the old
+    synchronous delete behavior. Useful for CI or throwaway containers
+    where the background reclaimer would be killed before finishing, or
+    when disk space must be reclaimed before returning.
+    """
+    return os.environ.get("DISABLE_FAST_CLEAN", "") not in ("", "0")
 
 
 class build_clean(build_rule_base):
@@ -12,6 +34,15 @@ class build_clean(build_rule_base):
     directory and below. Cleaning involves removing any
     "build" directories that are found, as well as running
     any "clean.do" files found.
+
+    Removal is asynchronous by default: each build directory is renamed
+    (an O(1) metadata operation, fast even on slow virtualized
+    filesystems like Docker Desktop bind mounts) into a session
+    directory under <repo_root>/.build_trash/, mirroring its original
+    path, and a single detached background process reclaims the trash
+    with "rm -rf". The tree is logically clean the moment this rule
+    returns; the disk space follows shortly after. Set
+    DISABLE_FAST_CLEAN=1 to force the old synchronous delete.
     """
     def _build(self, redo_1, redo_2, redo_3):
         pass  # We are overriding build instead since
@@ -36,8 +67,23 @@ class build_clean(build_rule_base):
             if "clean.do" in files and root != directory:
                 do_files_to_do.append(os.path.join(root, "clean"))
 
-        # Concurrently remove build directories using system calls. This
-        # executes much faster that python's rmtree.
+        # Remove the build directories:
+        if _fast_clean_disabled():
+            self._remove_synchronously(dirs_to_clean)
+        else:
+            self._rename_and_reclaim(directory, dirs_to_clean)
+
+        # Clean any subdirectories:
+        if do_files_to_do:
+            redo.redo(do_files_to_do)
+
+    @staticmethod
+    def _remove_synchronously(dirs_to_clean):
+        """
+        The old clean behavior: concurrently remove build directories using
+        system calls, blocking until every file is deleted. "rm -rf"
+        executes much faster than python's rmtree.
+        """
         def remove_directory(dir_to_clean):
             debug.debug_print("removing " + dir_to_clean)
             subprocess.run(["rm", "-rf", dir_to_clean], check=True)
@@ -50,9 +96,119 @@ class build_clean(build_rule_base):
                 except subprocess.CalledProcessError as e:
                     debug.debug_print("Error removing directory: " + str(e))
 
-        # Clean any subdirectories:
-        if do_files_to_do:
-            redo.redo(do_files_to_do)
+    @staticmethod
+    def _rename_and_reclaim(directory, dirs_to_clean):
+        """
+        The fast clean behavior: rename each build directory into a unique
+        session directory under <repo_root>/.build_trash/, mirroring its
+        original relative path, then detach a single background process
+        that reclaims all trash with "rm -rf". Renames are single
+        metadata operations, so this returns in a fraction of the time a
+        recursive delete takes on slow filesystems. Any build directory
+        that cannot be renamed (e.g. it sits on a different filesystem
+        than the trash directory) falls back to a synchronous "rm -rf".
+
+        Trash from previous cleans (e.g. orphaned because the container
+        died mid-reclaim) is adopted into this clean's reclaim batch, so
+        leftovers never accumulate past the next clean.
+        """
+        repo_root = filesystem.get_git_root(directory)
+        if repo_root is None:
+            # Not in a git repository, so there is no sensible stable
+            # location for the trash directory. Fall back to the old
+            # synchronous behavior.
+            build_clean._remove_synchronously(dirs_to_clean)
+            return
+        trash_root = os.path.join(repo_root, TRASH_DIR_NAME)
+
+        # Rename build directories into a unique session directory. The
+        # pid plus random token ensures overlapping or repeated cleans
+        # never collide, even across container restarts (pid reuse).
+        session_dir = os.path.join(
+            trash_root, str(os.getpid()) + "_" + secrets.token_hex(4)
+        )
+        fallback_dirs = []
+        for dir_to_clean in dirs_to_clean:
+            rel_path = os.path.relpath(dir_to_clean, repo_root)
+            if rel_path.startswith(os.pardir):
+                # Outside the repository root; rename destination would
+                # escape the trash directory, so just remove it in place.
+                fallback_dirs.append(dir_to_clean)
+                continue
+            # A reclaimer spawned by a previous clean may still be
+            # running and can delete our freshly-made parent directories
+            # in the window between makedirs and rename (it never touches
+            # a renamed build directory itself, since our session name is
+            # unique and only enumerated by cleans that start later). One
+            # retry wins that race deterministically, because the
+            # reclaimer only deletes paths that existed when it was
+            # spawned. Persistent failures (e.g. a cross-filesystem
+            # rename, EXDEV) fall back to synchronous removal.
+            trash_path = os.path.join(session_dir, rel_path)
+            for attempt in range(2):
+                try:
+                    os.makedirs(os.path.dirname(trash_path), exist_ok=True)
+                    os.rename(dir_to_clean, trash_path)
+                    debug.debug_print("trashing " + dir_to_clean)
+                    break
+                except OSError:
+                    if attempt == 1:
+                        fallback_dirs.append(dir_to_clean)
+        if fallback_dirs:
+            build_clean._remove_synchronously(fallback_dirs)
+
+        # Collect everything currently in the trash: our session directory
+        # plus any orphans from previous cleans. A concurrent clean's live
+        # session may also be adopted; racing "rm -rf" processes on the
+        # same tree are harmless (ENOENT is ignored by -f, and a
+        # concurrent rename losing its destination parent falls back to
+        # the synchronous path above).
+        try:
+            trash_paths = [
+                os.path.join(trash_root, entry) for entry in os.listdir(trash_root)
+            ]
+        except OSError:
+            trash_paths = []
+        if not trash_paths:
+            return
+
+        # Detach a single background reclaimer to delete the trash. The
+        # new session ensures it survives this process exiting, and the
+        # null stdio ensures it holds no pipe to a terminal that may be
+        # gone by the time it finishes. We intentionally do not wait on
+        # it; the deletion cost moves off the critical path. The
+        # reclaimer demotes itself to the lowest CPU and I/O priority
+        # (best effort; silently skipped where renice/ionice are
+        # unavailable) so a build started immediately after clean takes
+        # precedence. After the trash is deleted the trash directory
+        # itself is removed if it is empty (rmdir refuses otherwise, so
+        # a concurrent clean that is still filling it is left alone; a
+        # rename racing the rmdir falls back to the synchronous path
+        # above).
+        debug.debug_print(
+            "reclaiming in background: " + " ".join(trash_paths)
+        )
+        reclaim_script = (
+            "renice -n 19 -p $$ >/dev/null 2>&1;"
+            " ionice -c 3 -p $$ 2>/dev/null;"
+            ' rm -rf -- "$@";'
+            " rmdir -- \"$0\" 2>/dev/null"
+        )
+        try:
+            subprocess.Popen(
+                ["/bin/sh", "-c", reclaim_script, trash_root] + trash_paths,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError:
+            # If the reclaimer cannot even be spawned (no /bin/sh, or the
+            # system is out of resources), the build directories have
+            # already been renamed away, so the tree is logically clean.
+            # Leave the trash for the next clean to adopt rather than
+            # surfacing an error: clean is best effort and stays silent.
+            debug.debug_print("could not spawn background reclaimer")
 
     # No need to provide these for "redo clean"
     # def input_file_regex(self): pass

--- a/redo/rules/build_clean_all.py
+++ b/redo/rules/build_clean_all.py
@@ -2,19 +2,7 @@ import os.path
 from util import redo
 from base_classes.build_rule_base import build_rule_base
 from util import error
-import git
-
-
-def _get_git_root(path):
-    """Get the root directory of the adamant repository."""
-    try:
-        git_repo = git.Repo(path, search_parent_directories=True)
-        git_root = git_repo.git.rev_parse("--show-toplevel")
-    except BaseException:
-        error.error_abort(
-            "No valid git repository was found containing the directory: " + str(path)
-        )
-    return git_root
+from util import filesystem
 
 
 class build_clean_all(build_rule_base):
@@ -32,7 +20,12 @@ class build_clean_all(build_rule_base):
     def build(self, redo_1, redo_2, redo_3):
         # Figure out build directory location
         directory = os.path.abspath(os.path.dirname(redo_1))
-        git_root = _get_git_root(directory)
+        git_root = filesystem.get_git_root(directory)
+        if git_root is None:
+            error.error_abort(
+                "No valid git repository was found containing the directory: "
+                + str(directory)
+            )
 
         # Run redo clean from git root.
         redo.redo(os.path.join(git_root, "clean"))

--- a/redo/util/binary_meta.py
+++ b/redo/util/binary_meta.py
@@ -30,13 +30,9 @@ def _get_build_target_instance(target_name):
 
 
 def _get_git_root(path):
-    import git
+    from util import filesystem
 
-    try:
-        git_repo = git.Repo(path, search_parent_directories=True)
-        return git_repo.git.rev_parse("--show-toplevel")
-    except BaseException:
-        return None
+    return filesystem.get_git_root(path)
 
 
 def _get_git_info(path):

--- a/redo/util/filesystem.py
+++ b/redo/util/filesystem.py
@@ -35,6 +35,20 @@ def safe_symlink(filename, link_filename, overwrite=False):
             do_link()
 
 
+def get_git_root(path):
+    """
+    Return the root directory of the git repository containing path, or
+    None if path is not inside a git repository.
+    """
+    import git
+
+    try:
+        git_repo = git.Repo(path, search_parent_directories=True)
+        return git_repo.git.rev_parse("--show-toplevel")
+    except BaseException:
+        return None
+
+
 def recurse_through_repo(directory, ignore=["build", "alire"]):
     """
     This generator is a modified version of os.walk, except that it


### PR DESCRIPTION
## Problem

On slow virtualized filesystems (Docker Desktop bind mounts on macOS via VirtioFS), `redo clean` / `redo clean_all` can take **many minutes** on a bogged down or full-disk system. Deletion is one metadata round-trip per file across the host<->VM bridge, and build trees contain thousands of files.

## Change

`redo clean` now:
1. **Renames** each `build/` dir (a single O(1) metadata op) into a per-invocation session directory under `<repo_root>/.build_trash/`, mirroring its original path:
   ```
   src/components/command_router/build
     -> .build_trash/<pid>_<token>/src/components/command_router/build
   ```
2. **Detaches one background reclaimer** (`rm -rf` via `Popen(start_new_session=True)`, null stdio) over all trash and returns immediately.

The tree is logically clean the moment clean returns; disk space follows in the background.

Safety/robustness:
- **Orphan sweep**: every clean adopts all existing `.build_trash/` entries into its reclaim batch, so trash from a reclaimer killed mid-flight (container restart) never outlives the next clean.
- **Fallbacks**: cross-filesystem rename failure (`EXDEV`) or build dirs outside the repo root fall back to synchronous `rm -rf`; not inside a git repo falls back to the old behavior entirely.
- **`DISABLE_FAST_CLEAN=1`** forces the old synchronous delete (CI / throwaway containers / need-disk-now).
- `.build_trash/` starts with `.` so every build-system walk (`util/filesystem.py` and clean's own walk) already skips it; git-ignored; safe to delete manually at any time.
- Unique session names (pid + random token) make overlapping/repeated cleans collision-free; racing reclaimers degrade gracefully (`rm -f` ignores ENOENT).